### PR TITLE
fix: correct tag sorting and ranking for deleted tags

### DIFF
--- a/backend-go/handlers/tag_handler.go
+++ b/backend-go/handlers/tag_handler.go
@@ -134,9 +134,13 @@ func (h *TagHandler) GetTags(c *fiber.Ctx) error {
 		}
 
 		orderClause := dbColumn + " " + sortOrder
-		// Special case: when sorting by viewCount desc, also sort by created_at desc as secondary
-		if sortBy == "viewCount" && sortOrder == "desc" {
-			orderClause = "view_count DESC, created_at DESC"
+		// Special case: when sorting by viewCount, treat deleted tags as having 0 view count
+		if sortBy == "viewCount" {
+			if sortOrder == "desc" {
+				orderClause = "CASE WHEN is_deleted THEN 0 ELSE view_count END DESC, created_at DESC"
+			} else {
+				orderClause = "CASE WHEN is_deleted THEN 0 ELSE view_count END ASC, created_at ASC"
+			}
 		}
 		query = query.Order(orderClause)
 

--- a/backend-go/utils/utils.go
+++ b/backend-go/utils/utils.go
@@ -9,12 +9,13 @@ import (
 func CalculateTagRanks(db *gorm.DB) error {
 	// Use raw SQL for better performance and to avoid hooks
 	// DENSE_RANK() ensures no gaps in ranking when there are ties
+	// Treat deleted tags as having 0 view count for ranking purposes
 	sql := `
 		UPDATE tags t1
 		JOIN (
 			SELECT 
 				id,
-				DENSE_RANK() OVER (ORDER BY post_count DESC, created_at ASC) as new_rank
+				DENSE_RANK() OVER (ORDER BY CASE WHEN is_deleted THEN 0 ELSE view_count END DESC, created_at ASC) as new_rank
 			FROM tags
 		) t2 ON t1.id = t2.id
 		SET t1.rank = t2.new_rank


### PR DESCRIPTION
Fixed tag sorting to show deleted tags last by treating them as having 0 view count in sort logic. Updated tag rank calculation to use view_count instead of post_count and handle deleted tags appropriately.

Closes #37

Generated by Claude Code Bot