### PR TITLE
ref: add composite indexes to optimize tags and related endpoints

### DIFF
--- a/backend-go/models/tag.go
+++ b/backend-go/models/tag.go
@@ -5,19 +5,19 @@ import (
 )
 
 type Tag struct {
-	ID                   string     `gorm:"primaryKey;type:varchar(255);column:id" json:"id"`
-	Tag                  string     `gorm:"unique;not null;index;column:tag" json:"tag"`
-	ViewCount            int64      `gorm:"not null;column:view_count" json:"viewCount"`
-	PostCount            int64      `gorm:"not null;default:0;column:post_count" json:"postCount"`
-	Rank                 *int       `gorm:"column:rank;index" json:"rank"`
-	Heat                 float64    `gorm:"not null;default:0;column:heat;index" json:"heat"`
-	FanslyCreatedAt      time.Time  `gorm:"not null;column:fansly_created_at" json:"-"`
-	LastCheckedAt        *time.Time `gorm:"column:last_checked_at" json:"-"`
-	LastUsedForDiscovery *time.Time `gorm:"column:last_used_for_discovery" json:"-"`
-	IsDeleted            bool       `gorm:"not null;default:false;column:is_deleted" json:"isDeleted"`
-	DeletedDetectedAt    *time.Time `gorm:"column:deleted_detected_at" json:"deletedDetectedAt"`
-	CreatedAt            time.Time  `gorm:"not null;column:created_at;default:CURRENT_TIMESTAMP" json:"-"`
-	UpdatedAt            time.Time  `gorm:"not null;column:updated_at;default:CURRENT_TIMESTAMP" json:"-"`
+    ID                   string     `gorm:"primaryKey;type:varchar(255);column:id" json:"id"`
+    Tag                  string     `gorm:"unique;not null;index;column:tag" json:"tag"`
+    ViewCount            int64      `gorm:"not null;column:view_count;index:idx_tags_view_created,priority:1" json:"viewCount"`
+    PostCount            int64      `gorm:"not null;default:0;column:post_count;index:idx_tags_post_created,priority:1" json:"postCount"`
+    Rank                 *int       `gorm:"column:rank;index" json:"rank"`
+    Heat                 float64    `gorm:"not null;default:0;column:heat;index" json:"heat"`
+    FanslyCreatedAt      time.Time  `gorm:"not null;column:fansly_created_at" json:"-"`
+    LastCheckedAt        *time.Time `gorm:"column:last_checked_at" json:"-"`
+    LastUsedForDiscovery *time.Time `gorm:"column:last_used_for_discovery" json:"-"`
+    IsDeleted            bool       `gorm:"not null;default:false;column:is_deleted;index:idx_tags_is_deleted_deleted,priority:1" json:"isDeleted"`
+    DeletedDetectedAt    *time.Time `gorm:"column:deleted_detected_at;index:idx_tags_is_deleted_deleted,priority:2" json:"deletedDetectedAt"`
+    CreatedAt            time.Time  `gorm:"not null;column:created_at;default:CURRENT_TIMESTAMP;index:idx_tags_view_created,priority:2;index:idx_tags_post_created,priority:2" json:"-"`
+    UpdatedAt            time.Time  `gorm:"not null;column:updated_at;default:CURRENT_TIMESTAMP;index:idx_tags_updated_at" json:"-"`
 }
 
 func (Tag) TableName() string {

--- a/backend-go/models/tag_history.go
+++ b/backend-go/models/tag_history.go
@@ -5,14 +5,14 @@ import (
 )
 
 type TagHistory struct {
-	ID              uint      `gorm:"primaryKey;autoIncrement;column:id" json:"id"`
-	TagID           string    `gorm:"not null;index;type:varchar(255);column:tag_id" json:"tagId"`
-	ViewCount       int64     `gorm:"not null;column:view_count" json:"viewCount"`
-	Change          int64     `gorm:"not null;column:change" json:"change"`
-	PostCount       int64     `gorm:"not null;default:0;column:post_count" json:"postCount"`
-	PostCountChange int64     `gorm:"not null;default:0;column:post_count_change" json:"postCountChange"`
-	CreatedAt       time.Time `gorm:"not null;column:created_at;default:CURRENT_TIMESTAMP;index" json:"-"`
-	UpdatedAt       time.Time `gorm:"not null;column:updated_at;default:CURRENT_TIMESTAMP" json:"-"`
+    ID              uint      `gorm:"primaryKey;autoIncrement;column:id" json:"id"`
+    TagID           string    `gorm:"not null;index;type:varchar(255);column:tag_id;index:idx_tag_history_tag_created,priority:1" json:"tagId"`
+    ViewCount       int64     `gorm:"not null;column:view_count" json:"viewCount"`
+    Change          int64     `gorm:"not null;column:change" json:"change"`
+    PostCount       int64     `gorm:"not null;default:0;column:post_count" json:"postCount"`
+    PostCountChange int64     `gorm:"not null;default:0;column:post_count_change" json:"postCountChange"`
+    CreatedAt       time.Time `gorm:"not null;column:created_at;default:CURRENT_TIMESTAMP;index;index:idx_tag_history_tag_created,priority:2,sort:desc" json:"-"`
+    UpdatedAt       time.Time `gorm:"not null;column:updated_at;default:CURRENT_TIMESTAMP" json:"-"`
 }
 
 func (TagHistory) TableName() string {

--- a/backend-go/models/tag_relation_daily.go
+++ b/backend-go/models/tag_relation_daily.go
@@ -4,11 +4,11 @@ import "time"
 
 // TagRelationDaily stores daily co-usage counts of tags observed during discovery
 type TagRelationDaily struct {
-	TagID        string    `gorm:"primaryKey;type:varchar(255);column:tag_id;index:idx_trd_tag_bucket,priority:1" json:"tagId"`
-	RelatedTagID string    `gorm:"primaryKey;type:varchar(255);column:related_tag_id;index:idx_trd_related_tag" json:"relatedTagId"`
-	BucketDate   time.Time `gorm:"primaryKey;type:date;column:bucket_date;index:idx_tag_relations_daily_bucket;index:idx_trd_tag_bucket,priority:2" json:"bucketDate"`
-	CoCount      int64     `gorm:"not null;default:0;column:co_count" json:"coCount"`
-	LastSeenAt   time.Time `gorm:"not null;column:last_seen_at;default:CURRENT_TIMESTAMP" json:"lastSeenAt"`
+    TagID        string    `gorm:"primaryKey;type:varchar(255);column:tag_id;index:idx_trd_tag_bucket,priority:1;index:idx_trd_tag_bucket_rel,priority:1" json:"tagId"`
+    RelatedTagID string    `gorm:"primaryKey;type:varchar(255);column:related_tag_id;index:idx_trd_related_tag;index:idx_trd_tag_bucket_rel,priority:3" json:"relatedTagId"`
+    BucketDate   time.Time `gorm:"primaryKey;type:date;column:bucket_date;index:idx_tag_relations_daily_bucket;index:idx_trd_tag_bucket,priority:2;index:idx_trd_tag_bucket_rel,priority:2" json:"bucketDate"`
+    CoCount      int64     `gorm:"not null;default:0;column:co_count" json:"coCount"`
+    LastSeenAt   time.Time `gorm:"not null;column:last_seen_at;default:CURRENT_TIMESTAMP" json:"lastSeenAt"`
 
 	// Helpful indexes
 	// index on bucket for quick purge


### PR DESCRIPTION
Improve performance of related tags and tag listing queries without changing API behavior.

Add idx_trd_tag_bucket_rel on tag_relations_daily (tag_id, bucket_date, related_tag_id) to align with WHERE on tag_id/bucket_date and GROUP BY related_tag_id for /api/tags/related.

Add idx_tag_history_tag_created on tag_history (tag_id, created_at DESC) to support batch history fetches ordered by tag_id, created_at DESC.

Add indexes on tags:
- idx_tags_view_created (view_count, created_at) for default sort
- idx_tags_post_created (post_count, created_at) for postCount sort
- idx_tags_updated_at (updated_at) for updatedAt sort
- idx_tags_is_deleted_deleted (is_deleted, deleted_detected_at) for deleted-tag range filters

Keep changes minimal and compatible with GORM AutoMigrate; no data backfill required.

Closes #49

ZerGo0 Bot