### PR TITLE
ref: use view counts for tag change and make chart full width

### DIFF
--- a/backend-go/handlers/tag_handler.go
+++ b/backend-go/handlers/tag_handler.go
@@ -260,28 +260,28 @@ func (h *TagHandler) GetTags(c *fiber.Ctx) error {
 					ChangePercent:   0,
 				}
 
-				// Calculate change from previous point based on post count
-				if i < len(history)-1 {
-					previousPoint := history[i+1]
-					// Still track view count change for reference
-					viewChange := point.ViewCount - previousPoint.ViewCount
-					historyPoints[i].Change = viewChange
+        // Calculate change from previous point based on view count
+        if i < len(history)-1 {
+            previousPoint := history[i+1]
+            // Calculate view count change as primary metric
+            viewChange := point.ViewCount - previousPoint.ViewCount
+            historyPoints[i].Change = viewChange
 
-					// Calculate post count change as primary metric
-					postChange := point.PostCount - previousPoint.PostCount
-					historyPoints[i].PostCountChange = postChange
-					if previousPoint.PostCount > 0 {
-						historyPoints[i].ChangePercent = float64(postChange) / float64(previousPoint.PostCount) * 100
-					}
-				}
-			}
+            // Still track post count change for reference
+            postChange := point.PostCount - previousPoint.PostCount
+            historyPoints[i].PostCountChange = postChange
+            if previousPoint.ViewCount > 0 {
+                historyPoints[i].ChangePercent = float64(viewChange) / float64(previousPoint.ViewCount) * 100
+            }
+        }
+        }
 
-			// Calculate total change based on post count
-			if len(history) > 0 {
-				newest := history[0].PostCount
-				oldest := history[len(history)-1].PostCount
-				tagWithHist.TotalChange = newest - oldest
-			}
+        // Calculate total change based on view count
+        if len(history) > 0 {
+            newest := history[0].ViewCount
+            oldest := history[len(history)-1].ViewCount
+            tagWithHist.TotalChange = newest - oldest
+        }
 
 			if includeHistory {
 				tagWithHist.History = historyPoints

--- a/backend-go/main.go
+++ b/backend-go/main.go
@@ -70,7 +70,7 @@ func main() {
 		}
 	}
 
-    // Heat calculation removed; backend will always return heat = 0
+	// Heat calculation removed; backend will always return heat = 0
 
 	// Calculate initial ranks for creators if needed
 	var creatorCount int64

--- a/backend-go/utils/utils.go
+++ b/backend-go/utils/utils.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-    "gorm.io/gorm"
+	"gorm.io/gorm"
 )
 
 // CalculateTagRanks recalculates ranks for all tags

--- a/backend-go/workers/rank_calculator.go
+++ b/backend-go/workers/rank_calculator.go
@@ -45,18 +45,18 @@ func (w *RankCalculatorWorker) Run(ctx context.Context) error {
 }
 
 func (w *RankCalculatorWorker) calculateRanks() {
-    startTime := time.Now()
-    zap.L().Info("Starting rank calculation")
+	startTime := time.Now()
+	zap.L().Info("Starting rank calculation")
 
-    // Calculate tag ranks
-    if err := utils.CalculateTagRanks(w.db); err != nil {
-        zap.L().Error("Failed to calculate tag ranks", zap.Error(err))
-    }
+	// Calculate tag ranks
+	if err := utils.CalculateTagRanks(w.db); err != nil {
+		zap.L().Error("Failed to calculate tag ranks", zap.Error(err))
+	}
 
-    // Calculate creator ranks
-    if err := utils.CalculateCreatorRanks(w.db); err != nil {
-        zap.L().Error("Failed to calculate creator ranks", zap.Error(err))
-    }
+	// Calculate creator ranks
+	if err := utils.CalculateCreatorRanks(w.db); err != nil {
+		zap.L().Error("Failed to calculate creator ranks", zap.Error(err))
+	}
 
 	duration := time.Since(startTime)
 	zap.L().Info("Rank calculation completed",

--- a/backend-go/workers/statistics_calculator.go
+++ b/backend-go/workers/statistics_calculator.go
@@ -76,15 +76,15 @@ func (w *StatisticsCalculatorWorker) calculateTagStatistics(ctx context.Context)
 		return fmt.Errorf("failed to fetch previous statistics: %w", err)
 	}
 
-	// Calculate 24-hour changes based on post count
-	var change24h int64
-	var changePercent24h float64
-	if previousStats.ID != 0 {
-		change24h = totalPostCount - previousStats.TotalPostCount
-		if previousStats.TotalPostCount > 0 {
-			changePercent24h = (float64(change24h) / float64(previousStats.TotalPostCount)) * 100
-		}
-	}
+    // Calculate 24-hour changes based on view count
+    var change24h int64
+    var changePercent24h float64
+    if previousStats.ID != 0 {
+        change24h = totalViewCount - previousStats.TotalViewCount
+        if previousStats.TotalViewCount > 0 {
+            changePercent24h = (float64(change24h) / float64(previousStats.TotalViewCount)) * 100
+        }
+    }
 
 	// Create new statistics record
 	newStats := models.TagStatistics{

--- a/frontend/src/lib/components/TagHistory.svelte
+++ b/frontend/src/lib/components/TagHistory.svelte
@@ -338,7 +338,7 @@
   </CardHeader>
   <CardContent>
     <div class="space-y-4">
-      <div class="relative h-80">
+      <div class="relative h-80 w-full">
         <canvas bind:this={chartCanvas} class="h-full w-full"></canvas>
         {#if historyWithDates.length === 0}
           <div class="pointer-events-none absolute inset-0 flex items-center justify-center">

--- a/frontend/src/routes/tags/+page.svelte
+++ b/frontend/src/routes/tags/+page.svelte
@@ -214,17 +214,17 @@
     updateDateRangeParams();
   }
 
-  // Calculate change from history data based on post count
+  // Calculate change from history data based on view count
   function getTagChange(tag: { history?: Array<{ viewCount: number; postCount: number }> }) {
     if (!tag.history || tag.history.length === 0) {
       return { change: 0, percentage: 0 };
     }
 
     // History is in descending order (newest first)
-    const newestPostCount = tag.history[0].postCount || 0;
-    const oldestPostCount = tag.history[tag.history.length - 1].postCount || 0;
-    const totalChange = newestPostCount - oldestPostCount;
-    const percentage = oldestPostCount > 0 ? (totalChange / oldestPostCount) * 100 : 0;
+    const newestViewCount = tag.history[0].viewCount || 0;
+    const oldestViewCount = tag.history[tag.history.length - 1].viewCount || 0;
+    const totalChange = newestViewCount - oldestViewCount;
+    const percentage = oldestViewCount > 0 ? (totalChange / oldestViewCount) * 100 : 0;
 
     return { change: totalChange, percentage };
   }
@@ -261,13 +261,13 @@
       <CardContent>
         <div class="grid gap-4 sm:grid-cols-2">
           <div class="space-y-2">
-            <p class="text-muted-foreground text-sm">Total Posts</p>
+            <p class="text-muted-foreground text-sm">Total Views</p>
             <p class="text-2xl font-bold sm:text-3xl">
-              {formatNumber(data.statistics.totalPostCount || 0)}
+              {formatNumber(data.statistics.totalViewCount || 0)}
             </p>
           </div>
           <div class="space-y-2 sm:text-right">
-            <p class="text-muted-foreground text-sm">24-hour Post Change</p>
+            <p class="text-muted-foreground text-sm">24-hour View Change</p>
             {#if data.statistics.change24h !== 0}
               <div class="flex items-center gap-1 sm:justify-end">
                 {#if data.statistics.change24h > 0}
@@ -417,7 +417,7 @@
                     {/if}
                   </button>
                 </TableHead>
-                
+
                 <TableHead>
                   <button
                     class="hover:text-foreground flex items-center gap-1 transition-colors"


### PR DESCRIPTION
Backend: compute change, changePercent, and TotalChange from view counts. Calculate 24-hour change from totalViewCount instead of totalPostCount.

Frontend: display Total Views and 24-hour View Change using view-based metrics. getTagChange uses viewCount history. Chart container is now full width.

Closes #54

ZerGo0 Bot