### PR TITLE
fix: ignore '&' tags in discovery and relation aggregation

### DIFF
--- a/backend-go/handlers/tag_handler.go
+++ b/backend-go/handlers/tag_handler.go
@@ -260,28 +260,28 @@ func (h *TagHandler) GetTags(c *fiber.Ctx) error {
 					ChangePercent:   0,
 				}
 
-        // Calculate change from previous point based on view count
-        if i < len(history)-1 {
-            previousPoint := history[i+1]
-            // Calculate view count change as primary metric
-            viewChange := point.ViewCount - previousPoint.ViewCount
-            historyPoints[i].Change = viewChange
+				// Calculate change from previous point based on view count
+				if i < len(history)-1 {
+					previousPoint := history[i+1]
+					// Calculate view count change as primary metric
+					viewChange := point.ViewCount - previousPoint.ViewCount
+					historyPoints[i].Change = viewChange
 
-            // Still track post count change for reference
-            postChange := point.PostCount - previousPoint.PostCount
-            historyPoints[i].PostCountChange = postChange
-            if previousPoint.ViewCount > 0 {
-                historyPoints[i].ChangePercent = float64(viewChange) / float64(previousPoint.ViewCount) * 100
-            }
-        }
-        }
+					// Still track post count change for reference
+					postChange := point.PostCount - previousPoint.PostCount
+					historyPoints[i].PostCountChange = postChange
+					if previousPoint.ViewCount > 0 {
+						historyPoints[i].ChangePercent = float64(viewChange) / float64(previousPoint.ViewCount) * 100
+					}
+				}
+			}
 
-        // Calculate total change based on view count
-        if len(history) > 0 {
-            newest := history[0].ViewCount
-            oldest := history[len(history)-1].ViewCount
-            tagWithHist.TotalChange = newest - oldest
-        }
+			// Calculate total change based on view count
+			if len(history) > 0 {
+				newest := history[0].ViewCount
+				oldest := history[len(history)-1].ViewCount
+				tagWithHist.TotalChange = newest - oldest
+			}
 
 			if includeHistory {
 				tagWithHist.History = historyPoints

--- a/backend-go/workers/statistics_calculator.go
+++ b/backend-go/workers/statistics_calculator.go
@@ -76,15 +76,15 @@ func (w *StatisticsCalculatorWorker) calculateTagStatistics(ctx context.Context)
 		return fmt.Errorf("failed to fetch previous statistics: %w", err)
 	}
 
-    // Calculate 24-hour changes based on view count
-    var change24h int64
-    var changePercent24h float64
-    if previousStats.ID != 0 {
-        change24h = totalViewCount - previousStats.TotalViewCount
-        if previousStats.TotalViewCount > 0 {
-            changePercent24h = (float64(change24h) / float64(previousStats.TotalViewCount)) * 100
-        }
-    }
+	// Calculate 24-hour changes based on view count
+	var change24h int64
+	var changePercent24h float64
+	if previousStats.ID != 0 {
+		change24h = totalViewCount - previousStats.TotalViewCount
+		if previousStats.TotalViewCount > 0 {
+			changePercent24h = (float64(change24h) / float64(previousStats.TotalViewCount)) * 100
+		}
+	}
 
 	// Create new statistics record
 	newStats := models.TagStatistics{


### PR DESCRIPTION
- Add WHERE tag NOT LIKE '%&%' in getTagForDiscovery
- Skip '&' tags in suggestion parsing and source picking
- Exclude them from relation aggregation and updates
- Early-return in processDiscoveredTag to prevent propagation
- Provide SQL to delete existing '&' tag rows across related tables

Closes #56

ZerGo0 Bot