### PR TITLE
feat: add tag cleanup worker for low-view tags

### DIFF
--- a/backend-go/.env.example
+++ b/backend-go/.env.example
@@ -24,6 +24,7 @@ WORKER_DISCOVERY_INTERVAL=60000
 # Rank calculation worker interval (milliseconds)
 # How often to recalculate tag rankings
 RANK_CALCULATION_INTERVAL=60000
+WORKER_TAG_CLEANUP_INTERVAL=3600000
 
 # Fansly API Configuration
 # Optional: Authentication token for Fansly API (if required)

--- a/backend-go/config/config.go
+++ b/backend-go/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	WorkerDiscoveryInterval  int
 	RankCalculationInterval  int
 	WorkerStatisticsInterval int
+	WorkerTagCleanupInterval int
 	GlobalRateLimit          int
 	GlobalRateLimitWindow    int
 	APIGlobalRateLimit       int
@@ -42,6 +43,7 @@ func Load() *Config {
 		WorkerDiscoveryInterval:  getEnvInt("WORKER_DISCOVERY_INTERVAL", 60000*10),
 		RankCalculationInterval:  getEnvInt("RANK_CALCULATION_INTERVAL", 60000*10),
 		WorkerStatisticsInterval: getEnvInt("WORKER_STATISTICS_INTERVAL", 3600000), // Default to 1 hour
+		WorkerTagCleanupInterval: getEnvInt("WORKER_TAG_CLEANUP_INTERVAL", 3600000),
 		GlobalRateLimit:          getEnvInt("FANSLY_GLOBAL_RATE_LIMIT", 50),
 		GlobalRateLimitWindow:    getEnvInt("FANSLY_GLOBAL_RATE_LIMIT_WINDOW", 10),
 		APIGlobalRateLimit:       getEnvInt("API_GLOBAL_RATE_LIMIT", 600),

--- a/backend-go/main.go
+++ b/backend-go/main.go
@@ -102,6 +102,7 @@ func main() {
 	rankCalculator := workers.NewRankCalculatorWorker(db, cfg)
 	creatorUpdater := workers.NewCreatorUpdaterWorker(db, fanslyClient)
 	statisticsCalculator := workers.NewStatisticsCalculatorWorker(db, cfg)
+	tagCleanup := workers.NewTagCleanupWorker(db, cfg)
 
 	if err := workerManager.Register(tagUpdater); err != nil {
 		zap.L().Error("Failed to register tag updater", zap.Error(err))
@@ -117,6 +118,9 @@ func main() {
 	}
 	if err := workerManager.Register(statisticsCalculator); err != nil {
 		zap.L().Error("Failed to register statistics calculator", zap.Error(err))
+	}
+	if err := workerManager.Register(tagCleanup); err != nil {
+		zap.L().Error("Failed to register tag cleanup", zap.Error(err))
 	}
 
 	// Start workers if enabled
@@ -136,6 +140,9 @@ func main() {
 			}
 			if err := workerManager.Start("statistics-calculator"); err != nil {
 				zap.L().Error("Failed to start statistics calculator", zap.Error(err))
+			}
+			if err := workerManager.Start("tag-cleanup"); err != nil {
+				zap.L().Error("Failed to start tag cleanup", zap.Error(err))
 			}
 		}()
 	}

--- a/backend-go/workers/tag_cleanup.go
+++ b/backend-go/workers/tag_cleanup.go
@@ -1,0 +1,83 @@
+package workers
+
+import (
+	"context"
+	"fmt"
+	"ftoolbox/config"
+	"ftoolbox/models"
+	"time"
+
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+type TagCleanupWorker struct {
+	BaseWorker
+	db       *gorm.DB
+	minViews int64
+}
+
+func NewTagCleanupWorker(db *gorm.DB, cfg *config.Config) *TagCleanupWorker {
+	interval := time.Duration(cfg.WorkerTagCleanupInterval) * time.Millisecond
+
+	return &TagCleanupWorker{
+		BaseWorker: NewBaseWorker("tag-cleanup", interval),
+		db:         db,
+		minViews:   500,
+	}
+}
+
+func (w *TagCleanupWorker) Run(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	zap.L().Info("Running tag cleanup", zap.Int64("minViews", w.minViews))
+
+	var tagIDs []string
+	if err := w.db.Model(&models.Tag{}).
+		Where("view_count < ?", w.minViews).
+		Pluck("id", &tagIDs).Error; err != nil {
+		return fmt.Errorf("failed to load tags for cleanup: %w", err)
+	}
+
+	if len(tagIDs) == 0 {
+		zap.L().Debug("No tags to cleanup")
+		return nil
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	tx := w.db.Begin()
+
+	if err := tx.Where("tag_id IN ?", tagIDs).Delete(&models.TagHistory{}).Error; err != nil {
+		tx.Rollback()
+		return fmt.Errorf("failed to delete tag history: %w", err)
+	}
+
+	if err := tx.Where("tag_id IN ? OR related_tag_id IN ?", tagIDs, tagIDs).
+		Delete(&models.TagRelationDaily{}).Error; err != nil {
+		tx.Rollback()
+		return fmt.Errorf("failed to delete tag relations: %w", err)
+	}
+
+	result := tx.Where("id IN ?", tagIDs).Delete(&models.Tag{})
+	if result.Error != nil {
+		tx.Rollback()
+		return fmt.Errorf("failed to delete tags: %w", result.Error)
+	}
+
+	if err := tx.Commit().Error; err != nil {
+		return fmt.Errorf("failed to commit tag cleanup: %w", err)
+	}
+
+	zap.L().Info("Tag cleanup completed", zap.Int64("deleted", result.RowsAffected))
+
+	return nil
+}


### PR DESCRIPTION
Add a tag cleanup job that removes tags under 500 views along with related history and relations in a single transaction. Wire the worker into the manager and expose an interval via config/env for scheduled runs.

Closes #100

ZerGo0 Bot