### PR TITLE
feat: add tag cleanup for low-view tags

### DIFF
--- a/backend-go/workers/tag_cleanup.go
+++ b/backend-go/workers/tag_cleanup.go
@@ -36,14 +36,14 @@ func (w *TagCleanupWorker) Run(ctx context.Context) error {
 
 	zap.L().Info("Running tag cleanup", zap.Int64("minViews", w.minViews))
 
-	var tagIDs []string
+	var tagCount int64
 	if err := w.db.Model(&models.Tag{}).
 		Where("view_count < ?", w.minViews).
-		Pluck("id", &tagIDs).Error; err != nil {
-		return fmt.Errorf("failed to load tags for cleanup: %w", err)
+		Count(&tagCount).Error; err != nil {
+		return fmt.Errorf("failed to count tags for cleanup: %w", err)
 	}
 
-	if len(tagIDs) == 0 {
+	if tagCount == 0 {
 		zap.L().Debug("No tags to cleanup")
 		return nil
 	}
@@ -55,19 +55,22 @@ func (w *TagCleanupWorker) Run(ctx context.Context) error {
 	}
 
 	tx := w.db.Begin()
+	tagSubquery := tx.Model(&models.Tag{}).
+		Select("id").
+		Where("view_count < ?", w.minViews)
 
-	if err := tx.Where("tag_id IN ?", tagIDs).Delete(&models.TagHistory{}).Error; err != nil {
+	if err := tx.Where("tag_id IN (?)", tagSubquery).Delete(&models.TagHistory{}).Error; err != nil {
 		tx.Rollback()
 		return fmt.Errorf("failed to delete tag history: %w", err)
 	}
 
-	if err := tx.Where("tag_id IN ? OR related_tag_id IN ?", tagIDs, tagIDs).
+	if err := tx.Where("tag_id IN (?) OR related_tag_id IN (?)", tagSubquery, tagSubquery).
 		Delete(&models.TagRelationDaily{}).Error; err != nil {
 		tx.Rollback()
 		return fmt.Errorf("failed to delete tag relations: %w", err)
 	}
 
-	result := tx.Where("id IN ?", tagIDs).Delete(&models.Tag{})
+	result := tx.Where("view_count < ?", w.minViews).Delete(&models.Tag{})
 	if result.Error != nil {
 		tx.Rollback()
 		return fmt.Errorf("failed to delete tags: %w", result.Error)


### PR DESCRIPTION
Use subqueries with a count gate to avoid large IN lists while keeping the cleanup atomic and within placeholder limits

Closes #100

ZerGo0 Bot