### PR TITLE
feat: batch tag cleanup deletions to avoid oversized lists

### DIFF
--- a/backend-go/workers/tag_cleanup.go
+++ b/backend-go/workers/tag_cleanup.go
@@ -13,8 +13,9 @@ import (
 
 type TagCleanupWorker struct {
 	BaseWorker
-	db       *gorm.DB
-	minViews int64
+	db        *gorm.DB
+	minViews  int64
+	batchSize int
 }
 
 func NewTagCleanupWorker(db *gorm.DB, cfg *config.Config) *TagCleanupWorker {
@@ -24,6 +25,7 @@ func NewTagCleanupWorker(db *gorm.DB, cfg *config.Config) *TagCleanupWorker {
 		BaseWorker: NewBaseWorker("tag-cleanup", interval),
 		db:         db,
 		minViews:   500,
+		batchSize:  500,
 	}
 }
 
@@ -36,51 +38,55 @@ func (w *TagCleanupWorker) Run(ctx context.Context) error {
 
 	zap.L().Info("Running tag cleanup", zap.Int64("minViews", w.minViews))
 
-	var tagCount int64
-	if err := w.db.Model(&models.Tag{}).
-		Where("view_count < ?", w.minViews).
-		Count(&tagCount).Error; err != nil {
-		return fmt.Errorf("failed to count tags for cleanup: %w", err)
+	var totalDeleted int64
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		var tagIDs []string
+		if err := w.db.Model(&models.Tag{}).
+			Where("view_count < ?", w.minViews).
+			Order("id").
+			Limit(w.batchSize).
+			Pluck("id", &tagIDs).Error; err != nil {
+			return fmt.Errorf("failed to load tags for cleanup: %w", err)
+		}
+
+		if len(tagIDs) == 0 {
+			if totalDeleted == 0 {
+				zap.L().Debug("No tags to cleanup")
+			} else {
+				zap.L().Info("Tag cleanup completed", zap.Int64("deleted", totalDeleted))
+			}
+			return nil
+		}
+
+		tx := w.db.Begin()
+		if err := tx.Where("tag_id IN (?)", tagIDs).Delete(&models.TagHistory{}).Error; err != nil {
+			tx.Rollback()
+			return fmt.Errorf("failed to delete tag history: %w", err)
+		}
+
+		if err := tx.Where("tag_id IN (?) OR related_tag_id IN (?)", tagIDs, tagIDs).
+			Delete(&models.TagRelationDaily{}).Error; err != nil {
+			tx.Rollback()
+			return fmt.Errorf("failed to delete tag relations: %w", err)
+		}
+
+		result := tx.Where("id IN (?)", tagIDs).Delete(&models.Tag{})
+		if result.Error != nil {
+			tx.Rollback()
+			return fmt.Errorf("failed to delete tags: %w", result.Error)
+		}
+
+		if err := tx.Commit().Error; err != nil {
+			return fmt.Errorf("failed to commit tag cleanup: %w", err)
+		}
+
+		totalDeleted += result.RowsAffected
 	}
-
-	if tagCount == 0 {
-		zap.L().Debug("No tags to cleanup")
-		return nil
-	}
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-	}
-
-	tx := w.db.Begin()
-	tagSubquery := tx.Model(&models.Tag{}).
-		Select("id").
-		Where("view_count < ?", w.minViews)
-
-	if err := tx.Where("tag_id IN (?)", tagSubquery).Delete(&models.TagHistory{}).Error; err != nil {
-		tx.Rollback()
-		return fmt.Errorf("failed to delete tag history: %w", err)
-	}
-
-	if err := tx.Where("tag_id IN (?) OR related_tag_id IN (?)", tagSubquery, tagSubquery).
-		Delete(&models.TagRelationDaily{}).Error; err != nil {
-		tx.Rollback()
-		return fmt.Errorf("failed to delete tag relations: %w", err)
-	}
-
-	result := tx.Where("view_count < ?", w.minViews).Delete(&models.Tag{})
-	if result.Error != nil {
-		tx.Rollback()
-		return fmt.Errorf("failed to delete tags: %w", result.Error)
-	}
-
-	if err := tx.Commit().Error; err != nil {
-		return fmt.Errorf("failed to commit tag cleanup: %w", err)
-	}
-
-	zap.L().Info("Tag cleanup completed", zap.Int64("deleted", result.RowsAffected))
-
-	return nil
 }


### PR DESCRIPTION
Process eligible tag IDs in fixed-size batches, removing history/relations/tags per batch and looping until no more tags remain while keeping the 500-view threshold intact

Closes #100

ZerGo0 Bot