### PR TITLE
chore: refresh AGENTS guide for 2026-03-01 maintenance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,22 +6,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Name: FToolbox
 - Description: Full-stack web application delivering analytics and tooling for Fansly creators and consumers with a SvelteKit frontend and Go backend.
 - Key notes or warnings:
-  - Database schema lives in `backend-go/models`, with AutoMigrate applying changes on startup; update models instead of issuing manual migrations.
-  - Server listens on `PORT` (default `3000` from `backend-go/config/config.go`); the Taskfile only clears `3001` for the Air loop, so bind new services to `PORT`.
-  - Tag heat is deprecated and all responses force `heat = 0`; never surface or depend on legacy heat values in new logic.
-  - Fansly API calls must route through `backend-go/fansly/client.go`, which enforces global rate limiting and automatic 429 retries controlled by `FANSLY_GLOBAL_RATE_LIMIT` and `FANSLY_GLOBAL_RATE_LIMIT_WINDOW`.
-  - Cloudflare Pages builds ignore the `wrangler.toml [vars]` block; configure `PUBLIC_API_URL` and other frontend env vars in the Pages dashboard before builds succeed.
-  - Fansly auth: `FANSLY_AUTH_TOKEN` is read by the client and used when present.
+  - Database schema source of truth is `backend-go/models`; startup runs AutoMigrate via `backend-go/database/migrate.go`.
+  - Backend listens on `PORT` (default `3000` from `backend-go/config/config.go`); `Taskfile.yml` only clears `3001` for the Air loop.
+  - Tag heat is legacy-only in this codebase; API responses currently force `heat = 0`.
+  - Fansly API access must go through `backend-go/fansly/client.go`, which applies global throttling and retries.
+  - Cloudflare Pages needs `PUBLIC_API_URL` configured in the Pages dashboard at build time; the `wrangler.toml [vars]` block is not sufficient for SvelteKit builds.
 
 ## Global Rules
 - **NEVER** use emojis!
-- **NEVER** try to run the dev server unless a human explicitly tells you that you are a human and instructs you to run it.
-- **NEVER** try to build in the project directory; always build in the `/tmp` directory unless a human explicitly tells you that you are a human and instructs you to build in the project directory.
+- **NEVER** try to run the dev server unless explicitly asked.
+- **NEVER** try to build in the project directory; always build in the `/tmp` directory unless explicitly asked to build in the project directory.
 - **NEVER** use comments in code - code should be self-explanatory
 - **NEVER** cut corners, don't leave comments like `TODO: Implement X in the future here`! Always fully implement everything!
 - **NEVER** revert/delete any changes that you don't know about! Always assume that we are in the middle of a task and that the changes are intentional!
 - **ALWAYS** at the end of your turn, ask a follow-up question for the next logical step (**DON'T** ask questions like "Should I run tests?" or "Should I lint?", only ask questions that are relevant to the task at hand)
-
 ## Refactor Using Established Engineering Principles
 After generating or editing code, you must always refactor your changes using well-established software engineering principles. These apply every time, without relying on diff inspection.
 
@@ -41,12 +39,12 @@ After generating or editing code, you must always refactor your changes using we
 > Every change must simplify the codebase, reduce duplication, clarify intent, and make the system easier to maintain.
 
 ## High-Level Architecture
-- **Frontend:** SvelteKit 2 (Svelte 5) with Vite, Tailwind CSS v4, and shadcn-svelte; loaders build absolute API URLs using `PUBLIC_API_URL`.
-- **Backend:** Go 1.26 Fiber API using Zap logging, GORM (MySQL driver) targeting MariaDB, shared middleware for compression, CORS, ETag, and request limiting, serving JSON under `/api/*`.
-- **Workers:** Goroutine workers managed by `backend-go/workers/manager.go`; enablement and intervals come from env vars and statuses persist in the `workers` table.
-- **Fansly Integration:** `backend-go/fansly/client.go` centralizes authentication, retries, and global rate limiting for all Fansly requests.
-- **Schema Source of Truth:** `backend-go/models` combined with `backend-go/database/migrate.go` drives AutoMigrate; never mutate the database outside this layer.
-- **Infrastructure Utilities:** `Taskfile.yml` coordinates human dev loops (e.g., port cleanup) but must not be invoked from the agent.
+- **Frontend:** SvelteKit 2 + Svelte 5 + Vite + Tailwind v4 + shadcn-svelte primitives (`frontend/src/lib/components/ui`). App runs with `ssr = false` in `frontend/src/routes/+layout.ts`.
+- **Backend:** Go 1.26 Fiber API with Zap logging and GORM (MariaDB/MySQL driver), exposing JSON routes under `/api/*`.
+- **Workers:** Background jobs are managed through `backend-go/workers/manager.go`; worker state is persisted in the `workers` table.
+- **Fansly Integration:** `backend-go/fansly/client.go` owns auth header usage (`FANSLY_AUTH_TOKEN`), retries, and global throttling (`FANSLY_GLOBAL_RATE_LIMIT`, `FANSLY_GLOBAL_RATE_LIMIT_WINDOW`).
+- **Schema Source of Truth:** GORM models in `backend-go/models` with startup AutoMigrate in `backend-go/database/migrate.go`.
+- **Infrastructure:** `Taskfile.yml` exists for human workflows and starts dev loops; treat it as reference only in agent work.
 
 ## Project Guidelines
 
@@ -61,11 +59,13 @@ After generating or editing code, you must always refactor your changes using we
   - Format: `pnpm format`
   - **ALWAYS** run these after you are done making changes
 - Rules / conventions:
-  - **ALWAYS** build API requests with `$env/static/public` values (notably `PUBLIC_API_URL`) and emit absolute URLs from loaders or server-only modules.
-  - **ALWAYS** compose UI from shadcn-svelte primitives in `frontend/src/lib/components/ui` before introducing new components.
-  - **NEVER** nest interactive children inside trigger components; rely on the `local/no-nested-interactive` helpers.
-  - **NEVER** start dev loops, previews, or automated tests; run only the listed checks after making changes.
-  - **ALWAYS** keep Cloudflare Pages deployment metadata in sync between `frontend/wrangler.toml` and the Pages dashboard env configuration.
+  - **ALWAYS** build API requests with `$env/static/public` (`PUBLIC_API_URL`) and use absolute API URLs.
+  - **NEVER** hardcode backend hosts like `http://localhost:3000` in frontend code.
+  - **ALWAYS** compose UI from `frontend/src/lib/components/ui` primitives before adding new component patterns.
+  - **NEVER** nest interactive components inside trigger components; the local ESLint rule `local/no-nested-interactive` enforces this.
+  - **NEVER** run dev loops, previews, builds, or automated tests unless explicitly asked; run only the checks listed above.
+  - **ALWAYS** run the listed checks after frontend changes.
+  - **ALWAYS** keep Cloudflare Pages env settings aligned with frontend config for deployability.
 - Useful files:
   - `frontend/eslint.config.js`
   - `frontend/eslint-plugin-local/index.js`
@@ -83,12 +83,13 @@ After generating or editing code, you must always refactor your changes using we
   - Vet: `go vet ./...`
   - **ALWAYS** run these after you are done making changes
 - Rules / conventions:
-  - **ALWAYS** call `config.Load()` and pass the resulting config explicitly so default intervals and rate limits apply.
-  - **ALWAYS** persist schema changes in `backend-go/models` and let AutoMigrate handle DDL.
-  - **ALWAYS** return `{ "error": string }` JSON responses and log diagnostics with `zap.L()` instead of exposing internals.
-  - **ALWAYS** use the shared `fansly.Client` and global limiters for external API calls.
-  - **NEVER** spin up worker loops, Air, or other dev tooling from this agent; restrict work to code edits.
-  - **NEVER** run automated tests beyond `go fmt` and `go vet` unless a human explicitly asks.
+  - **ALWAYS** load configuration via `config.Load()` and pass config into worker/client setup.
+  - **ALWAYS** implement schema changes in `backend-go/models` and rely on AutoMigrate.
+  - **ALWAYS** return JSON errors in `{ "error": string }` shape for route-level failures.
+  - **ALWAYS** use the shared `fansly.Client` for Fansly API calls so retry/rate-limit behavior stays centralized.
+  - **NEVER** start Air/dev server/worker loops from agent tasks unless explicitly asked.
+  - **NEVER** run automated tests unless explicitly asked; run only `go fmt ./...` and `go vet ./...`.
+  - **ALWAYS** run the listed checks after backend changes.
 - Useful files:
   - `backend-go/config/config.go`
   - `backend-go/database/connection.go`
@@ -104,24 +105,25 @@ After generating or editing code, you must always refactor your changes using we
 - Package manager: pnpm (frontend), Go modules (backend)
 - Important Packages: `task`, `pnpm`, `air`
 - Checks:
-  - None at root; rely on the project checks listed above.
-  - **ALWAYS** run the listed project checks after you are done making changes
+  - Run frontend checks in `frontend`: `pnpm check`, `pnpm lint`, `pnpm format`
+  - Run backend checks in `backend-go`: `go fmt ./...`, `go vet ./...`
+  - **ALWAYS** run these after you are done making changes
 - Rules / conventions:
   - **ALWAYS** use `/tmp` for any build artifacts generated by the agent.
-  - **ALWAYS** treat `Taskfile.yml` and the `claude-code-github-bot-*.sh` scripts as references only.
-  - **NEVER** invoke `task watch-frontend`, `task watch-backend`, or other commands that start dev servers.
-  - **NEVER** alter automation scripts unless matching established patterns exactly.
-  - **NEVER** hunt for or execute additional test suites; only run the documented checks listed above.
+  - **ALWAYS** treat `Taskfile.yml` and `claude-code-github-bot-*.sh` scripts as references unless explicitly asked to edit them.
+  - **NEVER** invoke `task watch-frontend`, `task watch-backend`, or any command that starts a dev server unless explicitly asked.
+  - **NEVER** search for or execute additional test suites unless explicitly requested.
+  - **ALWAYS** run the listed checks after changes.
 - Useful files:
   - `Taskfile.yml`
   - `claude-code-github-bot-setup.sh`
   - `claude-code-github-bot-cleanup.sh`
 
 ## Key Architectural Patterns
-- **Error Handling:** Central Fiber error handler with Zap logging; route handlers return `{ "error": string }` payloads and avoid leaking internal details.
-- **Request Shaping:** Pagination, sorting, and time-window helpers in `backend-go/handlers/tag_handler.go` define reusable query parsing patterns for list endpoints.
-- **Rate Limiting:** Global middleware covers all requests, while sensitive POST routes apply stricter per-IP limiters—reuse the existing limiter helpers when adding routes.
-- **Ranking & Statistics:** Ranking utilities reside in `backend-go/utils/utils.go` and run through workers scheduled by `WorkerManager`; never spawn ad-hoc goroutines.
-- **Frontend Data Fetching:** Prefer SvelteKit loaders for initial data. Components may call the API using `PUBLIC_API_URL` from `$env/static/public`; never import non-public env values into client code.
-- **UI Composition:** Tailwind utility patterns and shadcn-svelte primitives in `frontend/src/lib/components/ui` are the first choice for new UI; do not duplicate styling.
- 
+- **Schema + Persistence:** GORM models (`backend-go/models`) are the authoritative schema, applied through AutoMigrate at startup.
+- **HTTP Shape:** Backend routes are grouped under `/api`; list endpoints return domain data with pagination metadata, and failures return `{ "error": string }`.
+- **Rate Limiting:** Global Fiber limiter wraps all requests, with tighter per-route limiters on sensitive POST endpoints in `backend-go/routes/routes.go`.
+- **Worker Orchestration:** Register workers via `WorkerManager`, persist worker state in DB, and avoid ad-hoc goroutines outside established worker flows.
+- **Ranking + Stats:** Rank and statistics calculations are centralized in `backend-go/utils/utils.go` and worker implementations, not in handlers.
+- **Frontend Data Flow:** Route loaders (`+page.ts`) fetch initial page data using `PUBLIC_API_URL`; avoid private env access from client-side code.
+- **UI Conventions:** Reuse shadcn-svelte primitives and local lint constraints (`local/no-nested-interactive`) rather than introducing custom interaction patterns.


### PR DESCRIPTION
Refine the existing AGENTS.md with the required structure, include all mandatory global rules verbatim, and add repo-verified guidance from frontend/backend READMEs, Taskfile, and config/routes/models sources.

Confirm .cursor/rules, .cursorrules, and
.github/copilot-instructions.md are absent, and rerun backend and frontend quality checks successfully.

Closes #107

ZerGo0 Bot