### PR TITLE
fix: align tag and creator metrics with selected history date

### DIFF
--- a/backend-go/handlers/creator_handler.go
+++ b/backend-go/handlers/creator_handler.go
@@ -55,6 +55,14 @@ type CreatorWithHistory struct {
 	History           []CreatorHistoryPoint `json:"history,omitempty"`
 }
 
+type creatorMetrics struct {
+	MediaLikes int64
+	PostLikes  int64
+	Followers  int64
+	ImageCount int64
+	VideoCount int64
+}
+
 func (h *CreatorHandler) GetCreators(c *fiber.Ctx) error {
 	page, _ := strconv.Atoi(c.Query("page", "1"))
 	limit, _ := strconv.Atoi(c.Query("limit", "20"))
@@ -75,159 +83,46 @@ func (h *CreatorHandler) GetCreators(c *fiber.Ctx) error {
 	}
 
 	offset := (page - 1) * limit
+	startDate := parseHistoryDate(historyStartDate)
+	endDate := parseHistoryDate(historyEndDate)
 
 	var creators []models.Creator
-	query := h.db.Model(&models.Creator{})
-
-	if search != "" {
-		query = query.Where("username LIKE ? OR display_name LIKE ?", "%"+search+"%", "%"+search+"%")
-	}
-
-	query = query.Where("rank IS NOT NULL")
+	query := applyCreatorSearch(h.db.Model(&models.Creator{}), search).Where("rank IS NOT NULL")
 
 	var total int64
 	query.Count(&total)
 
-	// Handle sorting
 	needsHistory := includeHistory
-	orderClause := "rank " + sortOrder
-	query = query.Order(orderClause).Limit(limit).Offset(offset)
+	query = query.Order("rank " + sortOrder).Limit(limit).Offset(offset)
 
 	if err := query.Find(&creators).Error; err != nil {
 		zap.L().Error("Failed to fetch creators", zap.Error(err))
 		return c.Status(500).JSON(fiber.Map{"error": "Failed to fetch creators"})
 	}
 
-	// If we need history, fetch it for each creator
-	var creatorsWithHistory []CreatorWithHistory
+	creatorIDs := collectCreatorIDs(creators)
+	creatorSnapshots, err := h.loadCreatorSnapshotsForRange(creatorIDs, endDate)
+	if err != nil {
+		zap.L().Error("Failed to fetch creator snapshots", zap.Error(err))
+		return c.Status(500).JSON(fiber.Map{"error": "Failed to fetch creator snapshots"})
+	}
+
 	if needsHistory {
-		// Collect all creator IDs for batch loading
-		creatorIDs := make([]string, len(creators))
-		creatorMap := make(map[string]models.Creator)
-		for i, creator := range creators {
-			creatorIDs[i] = creator.ID
-			creatorMap[creator.ID] = creator
-		}
-
-		// Build base query for all histories
-		histQuery := h.db.Model(&models.CreatorHistory{}).
-			Where("creator_id IN ?", creatorIDs).
-			Order("creator_id, created_at DESC")
-
-		// Apply date filters if provided
-		if historyStartDate != "" && historyEndDate != "" {
-			// Try parsing as RFC3339 (ISO 8601) first, then fall back to date-only format
-			startDate, err := time.Parse(time.RFC3339, historyStartDate)
-			if err != nil {
-				startDate, _ = time.Parse("2006-01-02", historyStartDate)
-			}
-			endDate, err := time.Parse(time.RFC3339, historyEndDate)
-			if err != nil {
-				endDate, _ = time.Parse("2006-01-02", historyEndDate)
-			}
-			histQuery = histQuery.Where("created_at >= ? AND created_at <= ?", startDate, endDate)
-		}
-
-		// Fetch all histories in one query
-		var allHistories []models.CreatorHistory
-		if err := histQuery.Find(&allHistories).Error; err != nil {
+		historyByCreator, err := h.loadCreatorHistoryByCreator(creatorIDs, startDate, endDate)
+		if err != nil {
 			zap.L().Error("Failed to fetch creator histories", zap.Error(err))
 			return c.Status(500).JSON(fiber.Map{"error": "Failed to fetch creator histories"})
 		}
 
-		// Group histories by creator ID
-		historyByCreator := make(map[string][]models.CreatorHistory)
-		for _, hist := range allHistories {
-			historyByCreator[hist.CreatorID] = append(historyByCreator[hist.CreatorID], hist)
-		}
-
-		// Process each creator with its history
-		for _, creator := range creators {
-			creatorWithHist := CreatorWithHistory{
-				ID:                creator.ID,
-				Username:          creator.Username,
-				DisplayName:       creator.DisplayName,
-				MediaLikes:        creator.MediaLikes,
-				PostLikes:         creator.PostLikes,
-				Followers:         creator.Followers,
-				ImageCount:        creator.ImageCount,
-				VideoCount:        creator.VideoCount,
-				Rank:              creator.Rank,
-				LastCheckedAt:     timeToUnixPtr(creator.LastCheckedAt),
-				IsDeleted:         creator.IsDeleted,
-				DeletedDetectedAt: timeToUnixPtr(creator.DeletedDetectedAt),
-				CreatedAt:         creator.CreatedAt.Unix(),
-				UpdatedAt:         creator.UpdatedAt.Unix(),
-			}
-
-			history := historyByCreator[creator.ID]
-
-			// Convert to CreatorHistoryPoint
-			historyPoints := make([]CreatorHistoryPoint, len(history))
-			for i, point := range history {
-				historyPoints[i] = CreatorHistoryPoint{
-					ID:         point.ID,
-					CreatorID:  point.CreatorID,
-					MediaLikes: point.MediaLikes,
-					PostLikes:  point.PostLikes,
-					Followers:  point.Followers,
-					ImageCount: point.ImageCount,
-					VideoCount: point.VideoCount,
-					CreatedAt:  point.CreatedAt.Unix(),
-					UpdatedAt:  point.UpdatedAt.Unix(),
-				}
-			}
-
-			if includeHistory {
-				creatorWithHist.History = historyPoints
-			}
-
-			creatorsWithHistory = append(creatorsWithHistory, creatorWithHist)
-		}
-	}
-
-	// Return response with consistent format
-	if needsHistory {
 		return c.JSON(fiber.Map{
-			"creators": creatorsWithHistory,
-			"pagination": fiber.Map{
-				"page":       page,
-				"limit":      limit,
-				"totalCount": total,
-				"totalPages": (total + int64(limit) - 1) / int64(limit),
-			},
+			"creators":   buildCreatorsWithHistory(creators, creatorSnapshots, historyByCreator),
+			"pagination": buildPagination(page, limit, total),
 		})
 	}
 
-	// For non-history responses, we need to convert creators to proper format
-	creatorsData := make([]map[string]any, len(creators))
-	for i, creator := range creators {
-		creatorsData[i] = map[string]any{
-			"id":                creator.ID,
-			"username":          creator.Username,
-			"displayName":       creator.DisplayName,
-			"mediaLikes":        creator.MediaLikes,
-			"postLikes":         creator.PostLikes,
-			"followers":         creator.Followers,
-			"imageCount":        creator.ImageCount,
-			"videoCount":        creator.VideoCount,
-			"rank":              creator.Rank,
-			"lastCheckedAt":     timeToUnixPtr(creator.LastCheckedAt),
-			"isDeleted":         creator.IsDeleted,
-			"deletedDetectedAt": timeToUnixPtr(creator.DeletedDetectedAt),
-			"createdAt":         creator.CreatedAt.Unix(),
-			"updatedAt":         creator.UpdatedAt.Unix(),
-		}
-	}
-
 	return c.JSON(fiber.Map{
-		"creators": creatorsData,
-		"pagination": fiber.Map{
-			"page":       page,
-			"limit":      limit,
-			"totalCount": total,
-			"totalPages": (total + int64(limit) - 1) / int64(limit),
-		},
+		"creators":   buildCreatorData(creators, creatorSnapshots),
+		"pagination": buildPagination(page, limit, total),
 	})
 }
 
@@ -358,4 +253,214 @@ func (h *CreatorHandler) RequestCreator(c *fiber.Ctx) error {
 		"message": "Creator added successfully",
 		"creator": creatorWithRank,
 	})
+}
+
+func applyCreatorSearch(query *gorm.DB, search string) *gorm.DB {
+	if search == "" {
+		return query
+	}
+
+	return query.Where("username LIKE ? OR display_name LIKE ?", "%"+search+"%", "%"+search+"%")
+}
+
+func collectCreatorIDs(creators []models.Creator) []string {
+	creatorIDs := make([]string, len(creators))
+	for i, creator := range creators {
+		creatorIDs[i] = creator.ID
+	}
+
+	return creatorIDs
+}
+
+func buildPagination(page, limit int, total int64) fiber.Map {
+	return fiber.Map{
+		"page":       page,
+		"limit":      limit,
+		"totalCount": total,
+		"totalPages": (total + int64(limit) - 1) / int64(limit),
+	}
+}
+
+func buildCreatorMetrics(creator models.Creator, snapshots map[string]models.CreatorHistory) creatorMetrics {
+	metrics := creatorMetrics{
+		MediaLikes: creator.MediaLikes,
+		PostLikes:  creator.PostLikes,
+		Followers:  creator.Followers,
+		ImageCount: creator.ImageCount,
+		VideoCount: creator.VideoCount,
+	}
+
+	if snapshot, ok := snapshots[creator.ID]; ok {
+		metrics.MediaLikes = snapshot.MediaLikes
+		metrics.PostLikes = snapshot.PostLikes
+		metrics.Followers = snapshot.Followers
+		metrics.ImageCount = snapshot.ImageCount
+		metrics.VideoCount = snapshot.VideoCount
+	}
+
+	return metrics
+}
+
+func buildCreatorHistoryPoints(history []models.CreatorHistory) []CreatorHistoryPoint {
+	historyPoints := make([]CreatorHistoryPoint, len(history))
+	for i, point := range history {
+		historyPoints[i] = CreatorHistoryPoint{
+			ID:         point.ID,
+			CreatorID:  point.CreatorID,
+			MediaLikes: point.MediaLikes,
+			PostLikes:  point.PostLikes,
+			Followers:  point.Followers,
+			ImageCount: point.ImageCount,
+			VideoCount: point.VideoCount,
+			CreatedAt:  point.CreatedAt.Unix(),
+			UpdatedAt:  point.UpdatedAt.Unix(),
+		}
+	}
+
+	return historyPoints
+}
+
+func buildCreatorWithHistory(
+	creator models.Creator,
+	snapshots map[string]models.CreatorHistory,
+	history []models.CreatorHistory,
+) CreatorWithHistory {
+	response := buildCreatorSummary(creator, snapshots)
+	response.History = buildCreatorHistoryPoints(history)
+	return response
+}
+
+func buildCreatorsWithHistory(
+	creators []models.Creator,
+	snapshots map[string]models.CreatorHistory,
+	historyByCreator map[string][]models.CreatorHistory,
+) []CreatorWithHistory {
+	creatorsWithHistory := make([]CreatorWithHistory, 0, len(creators))
+	for _, creator := range creators {
+		creatorsWithHistory = append(
+			creatorsWithHistory,
+			buildCreatorWithHistory(creator, snapshots, historyByCreator[creator.ID]),
+		)
+	}
+
+	return creatorsWithHistory
+}
+
+func buildCreatorData(creators []models.Creator, snapshots map[string]models.CreatorHistory) []map[string]any {
+	creatorsData := make([]map[string]any, len(creators))
+	for i, creator := range creators {
+		response := buildCreatorSummary(creator, snapshots)
+		creatorsData[i] = map[string]any{
+			"id":                response.ID,
+			"username":          response.Username,
+			"displayName":       response.DisplayName,
+			"mediaLikes":        response.MediaLikes,
+			"postLikes":         response.PostLikes,
+			"followers":         response.Followers,
+			"imageCount":        response.ImageCount,
+			"videoCount":        response.VideoCount,
+			"rank":              response.Rank,
+			"lastCheckedAt":     response.LastCheckedAt,
+			"isDeleted":         response.IsDeleted,
+			"deletedDetectedAt": response.DeletedDetectedAt,
+			"createdAt":         response.CreatedAt,
+			"updatedAt":         response.UpdatedAt,
+		}
+	}
+
+	return creatorsData
+}
+
+func buildCreatorSummary(
+	creator models.Creator,
+	snapshots map[string]models.CreatorHistory,
+) CreatorWithHistory {
+	metrics := buildCreatorMetrics(creator, snapshots)
+
+	return CreatorWithHistory{
+		ID:                creator.ID,
+		Username:          creator.Username,
+		DisplayName:       creator.DisplayName,
+		MediaLikes:        metrics.MediaLikes,
+		PostLikes:         metrics.PostLikes,
+		Followers:         metrics.Followers,
+		ImageCount:        metrics.ImageCount,
+		VideoCount:        metrics.VideoCount,
+		Rank:              creator.Rank,
+		LastCheckedAt:     timeToUnixPtr(creator.LastCheckedAt),
+		IsDeleted:         creator.IsDeleted,
+		DeletedDetectedAt: timeToUnixPtr(creator.DeletedDetectedAt),
+		CreatedAt:         creator.CreatedAt.Unix(),
+		UpdatedAt:         creator.UpdatedAt.Unix(),
+	}
+}
+
+func (h *CreatorHandler) loadCreatorSnapshotsForRange(
+	creatorIDs []string,
+	endDate *time.Time,
+) (map[string]models.CreatorHistory, error) {
+	if endDate == nil {
+		return map[string]models.CreatorHistory{}, nil
+	}
+
+	return loadCreatorSnapshots(h.db, creatorIDs, *endDate)
+}
+
+func (h *CreatorHandler) loadCreatorHistoryByCreator(
+	creatorIDs []string,
+	startDate *time.Time,
+	endDate *time.Time,
+) (map[string][]models.CreatorHistory, error) {
+	historyByCreator := make(map[string][]models.CreatorHistory)
+	if len(creatorIDs) == 0 {
+		return historyByCreator, nil
+	}
+
+	histQuery := h.db.Model(&models.CreatorHistory{}).
+		Where("creator_id IN ?", creatorIDs).
+		Order("creator_id, created_at DESC")
+
+	if startDate != nil {
+		histQuery = histQuery.Where("created_at >= ?", *startDate)
+	}
+	if endDate != nil {
+		histQuery = histQuery.Where("created_at <= ?", *endDate)
+	}
+
+	var allHistories []models.CreatorHistory
+	if err := histQuery.Find(&allHistories).Error; err != nil {
+		return nil, err
+	}
+
+	for _, history := range allHistories {
+		historyByCreator[history.CreatorID] = append(historyByCreator[history.CreatorID], history)
+	}
+
+	return historyByCreator, nil
+}
+
+func loadCreatorSnapshots(db *gorm.DB, creatorIDs []string, endDate time.Time) (map[string]models.CreatorHistory, error) {
+	if len(creatorIDs) == 0 {
+		return map[string]models.CreatorHistory{}, nil
+	}
+
+	var snapshots []models.CreatorHistory
+	if err := db.Table("creator_history AS ch").
+		Select("ch.id, ch.creator_id, ch.media_likes, ch.post_likes, ch.followers, ch.image_count, ch.video_count, ch.created_at, ch.updated_at").
+		Joins("JOIN (?) AS latest ON latest.id = ch.id",
+			db.Model(&models.CreatorHistory{}).
+				Select("creator_id, MAX(id) AS id").
+				Where("created_at <= ? AND creator_id IN ?", endDate, creatorIDs).
+				Group("creator_id"),
+		).
+		Scan(&snapshots).Error; err != nil {
+		return nil, err
+	}
+
+	snapshotByCreator := make(map[string]models.CreatorHistory, len(snapshots))
+	for _, snapshot := range snapshots {
+		snapshotByCreator[snapshot.CreatorID] = snapshot
+	}
+
+	return snapshotByCreator, nil
 }

--- a/backend-go/handlers/history_dates.go
+++ b/backend-go/handlers/history_dates.go
@@ -1,0 +1,21 @@
+package handlers
+
+import "time"
+
+func parseHistoryDate(value string) *time.Time {
+	if value == "" {
+		return nil
+	}
+
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err == nil {
+		return &parsed
+	}
+
+	parsed, err = time.Parse("2006-01-02", value)
+	if err == nil {
+		return &parsed
+	}
+
+	return nil
+}

--- a/backend-go/handlers/tag_handler.go
+++ b/backend-go/handlers/tag_handler.go
@@ -34,6 +34,7 @@ type HistoryPoint struct {
 	ViewCount       int64   `json:"viewCount"`
 	Change          int64   `json:"change"`
 	PostCount       int64   `json:"postCount"`
+	Ratio           float64 `json:"ratio"`
 	PostCountChange int64   `json:"postCountChange"`
 	CreatedAt       int64   `json:"createdAt"`
 	UpdatedAt       int64   `json:"updatedAt"`
@@ -45,6 +46,7 @@ type TagWithHistory struct {
 	Tag                  string         `json:"tag"`
 	ViewCount            int64          `json:"viewCount"`
 	PostCount            int64          `json:"postCount"`
+	Ratio                float64        `json:"ratio"`
 	Rank                 *int           `json:"rank"`
 	Heat                 float64        `json:"heat"`
 	FanslyCreatedAt      *int64         `json:"fanslyCreatedAt"`
@@ -56,6 +58,28 @@ type TagWithHistory struct {
 	UpdatedAt            int64          `json:"updatedAt"`
 	History              []HistoryPoint `json:"history,omitempty"`
 	TotalChange          int64          `json:"totalChange"`
+}
+
+type tagMetrics struct {
+	ViewCount int64
+	PostCount int64
+	Ratio     float64
+}
+
+type relatedTagAggregate struct {
+	ID          string  `json:"id"`
+	Tag         string  `json:"tag"`
+	RPostCount  int64   `json:"rPostCount"`
+	NormSum     float64 `json:"normSum"`
+	CoverageCnt int64   `json:"coverageCnt"`
+}
+
+type relatedTagScore struct {
+	ID         string
+	Tag        string
+	NormAvg    float64
+	Coverage   float64
+	FinalScore float64
 }
 
 func extractHashtags(q string) []string {
@@ -86,38 +110,12 @@ func (h *TagHandler) GetTags(c *fiber.Ctx) error {
 	page, _ := strconv.Atoi(c.Query("page", "1"))
 	limit, _ := strconv.Atoi(c.Query("limit", "20"))
 	search := c.Query("search")
+	sortBy := strings.ToLower(c.Query("sortBy", "rank"))
 	sortOrder := strings.ToLower(c.Query("sortOrder", "asc"))
 	includeHistory := c.Query("includeHistory") == "true"
 	historyStartDate := c.Query("historyStartDate")
 	historyEndDate := c.Query("historyEndDate")
 	tagsParam := c.Query("tags")
-
-	// Parse tags parameter if provided
-	var targetTags []string
-	if tagsParam != "" {
-		// Split by comma and trim whitespace
-		targetTags = strings.Split(tagsParam, ",")
-		for i := range targetTags {
-			targetTags[i] = strings.TrimSpace(targetTags[i])
-		}
-		// Remove empty strings
-		filtered := targetTags[:0]
-		for _, tag := range targetTags {
-			if tag != "" {
-				filtered = append(filtered, tag)
-			}
-		}
-		targetTags = filtered
-	}
-
-	if len(targetTags) == 0 {
-		if hs := extractHashtags(search); len(hs) > 0 {
-			targetTags = hs
-			search = ""
-		} else if strings.HasPrefix(strings.TrimSpace(search), "#") {
-			search = strings.TrimLeft(strings.TrimSpace(search), "#")
-		}
-	}
 
 	if page < 1 {
 		page = 1
@@ -125,33 +123,24 @@ func (h *TagHandler) GetTags(c *fiber.Ctx) error {
 	if limit < 1 || limit > 100 {
 		limit = 20
 	}
-	if sortOrder != "asc" && sortOrder != "desc" {
-		sortOrder = "asc"
-	}
+	sortBy = sanitizeTagSortBy(sortBy)
+	sortOrder = sanitizeSortOrder(sortOrder)
 
 	offset := (page - 1) * limit
+	startDate := parseHistoryDate(historyStartDate)
+	endDate := parseHistoryDate(historyEndDate)
+	targetTags, requestedTagsFilteredOut := parseRequestedTags(tagsParam)
+	search, targetTags = resolveTagSearch(search, targetTags)
 
 	var tags []models.Tag
-	query := h.db.Model(&models.Tag{})
-
-	// If tags parameter is provided, filter by those specific tags
-	if len(targetTags) > 0 {
-		query = query.Where("tag IN ?", targetTags)
-	} else if search != "" {
-		// Only apply search filter if tags parameter is not provided
-		query = query.Where("tag LIKE ?", "%"+search+"%")
-	}
-
-	query = query.Where("rank IS NOT NULL")
+	query := applyTagFilters(h.db.Model(&models.Tag{}), search, targetTags, requestedTagsFilteredOut).
+		Where("rank IS NOT NULL")
 
 	var total int64
 	query.Count(&total)
 
-	// Handle sorting
 	needsHistory := includeHistory
-
-	orderClause := "rank " + sortOrder
-	query = query.Order(orderClause)
+	query = h.applyTagSort(query, sortBy, sortOrder, endDate)
 
 	if len(targetTags) == 0 {
 		query = query.Limit(limit).Offset(offset)
@@ -162,180 +151,29 @@ func (h *TagHandler) GetTags(c *fiber.Ctx) error {
 		return c.Status(500).JSON(fiber.Map{"error": "Failed to fetch tags"})
 	}
 
-	// If we need history, fetch it for each tag
-	var tagsWithHistory []TagWithHistory
-	if needsHistory {
-		// Collect all tag IDs for batch loading
-		tagIDs := make([]string, len(tags))
-		tagMap := make(map[string]models.Tag)
-		for i, tag := range tags {
-			tagIDs[i] = tag.ID
-			tagMap[tag.ID] = tag
-		}
-
-		// Process in batches to avoid too many placeholders
-		const batchSize = 1000
-		var allHistories []models.TagHistory
-
-		for i := 0; i < len(tagIDs); i += batchSize {
-			end := min(i+batchSize, len(tagIDs))
-			batchIDs := tagIDs[i:end]
-
-			// Build base query for this batch
-			histQuery := h.db.Model(&models.TagHistory{}).
-				Where("tag_id IN ?", batchIDs).
-				Order("tag_id, created_at DESC")
-
-			// Apply date filters if provided
-			if historyStartDate != "" && historyEndDate != "" {
-				// Try parsing as RFC3339 (ISO 8601) first, then fall back to date-only format
-				startDate, err := time.Parse(time.RFC3339, historyStartDate)
-				if err != nil {
-					startDate, _ = time.Parse("2006-01-02", historyStartDate)
-				}
-				endDate, err := time.Parse(time.RFC3339, historyEndDate)
-				if err != nil {
-					endDate, _ = time.Parse("2006-01-02", historyEndDate)
-				}
-				histQuery = histQuery.Where("created_at >= ? AND created_at <= ?", startDate, endDate)
-			}
-
-			// Fetch histories for this batch
-			var batchHistories []models.TagHistory
-			if err := histQuery.Find(&batchHistories).Error; err != nil {
-				zap.L().Error("Failed to fetch tag histories", zap.Error(err))
-				return c.Status(500).JSON(fiber.Map{"error": "Failed to fetch tag histories"})
-			}
-			allHistories = append(allHistories, batchHistories...)
-		}
-
-		// Group histories by tag ID
-		historyByTag := make(map[string][]models.TagHistory)
-		for _, hist := range allHistories {
-			historyByTag[hist.TagID] = append(historyByTag[hist.TagID], hist)
-		}
-
-		// Process each tag with its history
-		for _, tag := range tags {
-			// Show 0 view count for deleted tags
-			viewCount := tag.ViewCount
-			if tag.IsDeleted {
-				viewCount = 0
-			}
-
-			tagWithHist := TagWithHistory{
-				ID:                   tag.ID,
-				Tag:                  tag.Tag,
-				ViewCount:            viewCount,
-				PostCount:            tag.PostCount,
-				Rank:                 tag.Rank,
-				Heat:                 0,
-				FanslyCreatedAt:      new(timeToUnix(tag.FanslyCreatedAt)),
-				LastCheckedAt:        timeToUnixPtr(tag.LastCheckedAt),
-				LastUsedForDiscovery: timeToUnixPtr(tag.LastUsedForDiscovery),
-				IsDeleted:            tag.IsDeleted,
-				DeletedDetectedAt:    timeToUnixPtr(tag.DeletedDetectedAt),
-				CreatedAt:            tag.CreatedAt.Unix(),
-				UpdatedAt:            tag.UpdatedAt.Unix(),
-			}
-
-			history := historyByTag[tag.ID]
-
-			// Calculate changes and convert to HistoryPoint
-			historyPoints := make([]HistoryPoint, len(history))
-			for i, point := range history {
-				historyPoints[i] = HistoryPoint{
-					ID:              point.ID,
-					TagID:           point.TagID,
-					ViewCount:       point.ViewCount,
-					Change:          0,
-					PostCount:       point.PostCount,
-					PostCountChange: 0,
-					CreatedAt:       point.CreatedAt.Unix(),
-					UpdatedAt:       point.UpdatedAt.Unix(),
-					ChangePercent:   0,
-				}
-
-				// Calculate change from previous point based on view count
-				if i < len(history)-1 {
-					previousPoint := history[i+1]
-					// Calculate view count change as primary metric
-					viewChange := point.ViewCount - previousPoint.ViewCount
-					historyPoints[i].Change = viewChange
-
-					// Still track post count change for reference
-					postChange := point.PostCount - previousPoint.PostCount
-					historyPoints[i].PostCountChange = postChange
-					if previousPoint.ViewCount > 0 {
-						historyPoints[i].ChangePercent = float64(viewChange) / float64(previousPoint.ViewCount) * 100
-					}
-				}
-			}
-
-			// Calculate total change based on view count
-			if len(history) > 0 {
-				newest := history[0].ViewCount
-				oldest := history[len(history)-1].ViewCount
-				tagWithHist.TotalChange = newest - oldest
-			}
-
-			if includeHistory {
-				tagWithHist.History = historyPoints
-			}
-
-			tagsWithHistory = append(tagsWithHistory, tagWithHist)
-		}
-
+	tagIDs := collectTagIDs(tags)
+	tagSnapshots, err := h.loadTagSnapshotsForRange(tagIDs, endDate)
+	if err != nil {
+		zap.L().Error("Failed to fetch tag snapshots", zap.Error(err))
+		return c.Status(500).JSON(fiber.Map{"error": "Failed to fetch tag snapshots"})
 	}
 
-	// Return response with consistent format
 	if needsHistory {
+		historyByTag, err := h.loadTagHistoryByTag(tagIDs, startDate, endDate)
+		if err != nil {
+			zap.L().Error("Failed to fetch tag histories", zap.Error(err))
+			return c.Status(500).JSON(fiber.Map{"error": "Failed to fetch tag histories"})
+		}
+
 		return c.JSON(fiber.Map{
-			"tags": tagsWithHistory,
-			"pagination": fiber.Map{
-				"page":       page,
-				"limit":      limit,
-				"totalCount": total,
-				"totalPages": (total + int64(limit) - 1) / int64(limit),
-			},
+			"tags":       buildTagsWithHistory(tags, tagSnapshots, historyByTag, endDate),
+			"pagination": buildPagination(page, limit, total),
 		})
 	}
 
-	// For non-history responses, we need to convert tags to proper format
-
-	tagsData := make([]map[string]any, len(tags))
-	for i, tag := range tags {
-		// Show 0 view count for deleted tags
-		viewCount := tag.ViewCount
-		if tag.IsDeleted {
-			viewCount = 0
-		}
-
-		tagsData[i] = map[string]any{
-			"id":                   tag.ID,
-			"tag":                  tag.Tag,
-			"viewCount":            viewCount,
-			"postCount":            tag.PostCount,
-			"rank":                 tag.Rank,
-			"heat":                 0,
-			"fanslyCreatedAt":      new(timeToUnix(tag.FanslyCreatedAt)),
-			"lastCheckedAt":        timeToUnixPtr(tag.LastCheckedAt),
-			"lastUsedForDiscovery": timeToUnixPtr(tag.LastUsedForDiscovery),
-			"isDeleted":            tag.IsDeleted,
-			"deletedDetectedAt":    timeToUnixPtr(tag.DeletedDetectedAt),
-			"createdAt":            tag.CreatedAt.Unix(),
-			"updatedAt":            tag.UpdatedAt.Unix(),
-		}
-	}
-
 	return c.JSON(fiber.Map{
-		"tags": tagsData,
-		"pagination": fiber.Map{
-			"page":       page,
-			"limit":      limit,
-			"totalCount": total,
-			"totalPages": (total + int64(limit) - 1) / int64(limit),
-		},
+		"tags":       buildTagData(tags, tagSnapshots, endDate),
+		"pagination": buildPagination(page, limit, total),
 	})
 }
 
@@ -389,7 +227,9 @@ func (h *TagHandler) GetBannedTags(c *fiber.Ctx) error {
 	offset := (page - 1) * limit
 
 	var tags []models.Tag
-	query := h.db.Model(&models.Tag{}).Where("is_deleted = ?", true)
+	query := h.db.Model(&models.Tag{}).
+		Where("is_deleted = ?", true).
+		Where("tag NOT LIKE ?", "%+%")
 
 	if hs := extractHashtags(search); len(hs) > 0 {
 		query = query.Where("tag IN ?", hs)
@@ -442,19 +282,31 @@ func (h *TagHandler) GetBannedTags(c *fiber.Ctx) error {
 	}
 
 	// Total banned tags
-	h.db.Model(&models.Tag{}).Where("is_deleted = ?", true).Count(&stats.TotalBanned)
+	h.db.Model(&models.Tag{}).
+		Where("is_deleted = ?", true).
+		Where("tag NOT LIKE ?", "%+%").
+		Count(&stats.TotalBanned)
 
 	// Banned in last 24 hours
 	oneDayAgo := time.Now().Add(-24 * time.Hour)
-	h.db.Model(&models.Tag{}).Where("is_deleted = ? AND deleted_detected_at >= ?", true, oneDayAgo).Count(&stats.BannedLast24h)
+	h.db.Model(&models.Tag{}).
+		Where("is_deleted = ? AND deleted_detected_at >= ?", true, oneDayAgo).
+		Where("tag NOT LIKE ?", "%+%").
+		Count(&stats.BannedLast24h)
 
 	// Banned in last 7 days
 	sevenDaysAgo := time.Now().Add(-7 * 24 * time.Hour)
-	h.db.Model(&models.Tag{}).Where("is_deleted = ? AND deleted_detected_at >= ?", true, sevenDaysAgo).Count(&stats.BannedLast7d)
+	h.db.Model(&models.Tag{}).
+		Where("is_deleted = ? AND deleted_detected_at >= ?", true, sevenDaysAgo).
+		Where("tag NOT LIKE ?", "%+%").
+		Count(&stats.BannedLast7d)
 
 	// Banned in last 30 days
 	thirtyDaysAgo := time.Now().Add(-30 * 24 * time.Hour)
-	h.db.Model(&models.Tag{}).Where("is_deleted = ? AND deleted_detected_at >= ?", true, thirtyDaysAgo).Count(&stats.BannedLast30d)
+	h.db.Model(&models.Tag{}).
+		Where("is_deleted = ? AND deleted_detected_at >= ?", true, thirtyDaysAgo).
+		Where("tag NOT LIKE ?", "%+%").
+		Count(&stats.BannedLast30d)
 
 	return c.JSON(fiber.Map{
 		"tags": tags,
@@ -476,9 +328,8 @@ func (h *TagHandler) RequestTag(c *fiber.Ctx) error {
 	if err := c.BodyParser(&req); err != nil {
 		return c.Status(400).JSON(fiber.Map{"error": "Invalid request body"})
 	}
-
-	if req.Tag == "" {
-		return c.Status(400).JSON(fiber.Map{"error": "Tag is required"})
+	if validationError := validateRequestedTag(req.Tag); validationError != "" {
+		return c.Status(400).JSON(fiber.Map{"error": validationError})
 	}
 
 	// Check if tag already exists
@@ -598,7 +449,10 @@ func (h *TagHandler) GetRelatedTags(c *fiber.Ctx) error {
 
 	// Resolve to IDs
 	var srcTags []models.Tag
-	if err := h.db.Model(&models.Tag{}).Where("tag IN ?", inputs).Find(&srcTags).Error; err != nil {
+	if err := h.db.Model(&models.Tag{}).
+		Where("tag IN ?", inputs).
+		Where("tag NOT LIKE ?", "%+%").
+		Find(&srcTags).Error; err != nil {
 		zap.L().Error("Failed to resolve tags", zap.Error(err))
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Failed to resolve tags"})
 	}
@@ -630,14 +484,7 @@ func (h *TagHandler) GetRelatedTags(c *fiber.Ctx) error {
 	}
 
 	// Query base aggregates; compute popularity shaping and final score in Go for portability
-	type smartRow struct {
-		ID          string  `json:"id"`
-		Tag         string  `json:"tag"`
-		RPostCount  int64   `json:"rPostCount"`
-		NormSum     float64 `json:"normSum"`
-		CoverageCnt int64   `json:"coverageCnt"`
-	}
-	var srows []smartRow
+	var srows []relatedTagAggregate
 
 	// Use CAST to float to ensure floating division across dialects
 	selectExpr := strings.Join([]string{
@@ -655,6 +502,7 @@ func (h *TagHandler) GetRelatedTags(c *fiber.Ctx) error {
 		Where("tr.tag_id IN ?", srcIDs).
 		Where("tr.bucket_date >= ?", cutoff).
 		Where("t.is_deleted = ?", false).
+		Where("t.tag NOT LIKE ?", "%+%").
 		Where("t.view_count >= ?", minViewCount).
 		Where("tr.related_tag_id NOT IN ?", srcIDs).
 		Group("t.id, t.tag, t.post_count").
@@ -665,49 +513,7 @@ func (h *TagHandler) GetRelatedTags(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Failed to fetch related tags"})
 	}
 
-	numInputs := float64(len(srcIDs))
-	// Compute final scores and sort
-	type scored struct {
-		ID         string
-		Tag        string
-		NormAvg    float64
-		Coverage   float64
-		FinalScore float64
-	}
-	scoredRows := make([]scored, 0, len(srows))
-	for _, r := range srows {
-		// Safety for division
-		na := 0.0
-		if numInputs > 0 {
-			na = r.NormSum / numInputs
-		}
-		cov := 0.0
-		if numInputs > 0 {
-			cov = float64(r.CoverageCnt) / numInputs
-		}
-		// Popularity shaping: gentle boost to avoid ultra-rare dominating
-		pc := float64(r.RPostCount)
-		if pc < 0 {
-			pc = 0
-		}
-		if pc > 50000 {
-			pc = 50000
-		}
-		popBoost := 1.0
-		// Avoid NaN if log1p(0) -> 0; keep boost >= 1 slightly for non-zero
-		logv := math.Log1p(pc)
-		if logv > 0 {
-			popBoost = math.Pow(logv, 0.2)
-		}
-		final := na * cov * popBoost
-		scoredRows = append(scoredRows, scored{
-			ID:         r.ID,
-			Tag:        r.Tag,
-			NormAvg:    na,
-			Coverage:   cov,
-			FinalScore: final,
-		})
-	}
+	scoredRows := scoreRelatedTags(srows, len(srcIDs))
 
 	sort.Slice(scoredRows, func(i, j int) bool {
 		return scoredRows[i].FinalScore > scoredRows[j].FinalScore
@@ -745,7 +551,371 @@ func timeToUnixPtr(t *time.Time) *int64 {
 	if t == nil {
 		return nil
 	}
-	return new(t.Unix())
+	return ptr(t.Unix())
+}
+
+func sanitizeTagSortBy(sortBy string) string {
+	if sortBy == "ratio" {
+		return "ratio"
+	}
+	return "rank"
+}
+
+func sanitizeSortOrder(sortOrder string) string {
+	if sortOrder == "desc" {
+		return "desc"
+	}
+	return "asc"
+}
+
+func parseRequestedTags(tagsParam string) ([]string, bool) {
+	if tagsParam == "" {
+		return nil, false
+	}
+
+	parts := strings.Split(tagsParam, ",")
+	filtered := make([]string, 0, len(parts))
+	for _, part := range parts {
+		tag := strings.TrimSpace(part)
+		if tag != "" && !utils.TagNameHasPlus(tag) {
+			filtered = append(filtered, tag)
+		}
+	}
+
+	return filtered, len(filtered) == 0
+}
+
+func validateRequestedTag(tag string) string {
+	if tag == "" {
+		return "Tag is required"
+	}
+	if utils.TagNameHasPlus(tag) {
+		return "Tags containing '+' are not supported"
+	}
+	return ""
+}
+
+func resolveTagSearch(search string, targetTags []string) (string, []string) {
+	if len(targetTags) > 0 {
+		return search, targetTags
+	}
+
+	if hashtags := extractHashtags(search); len(hashtags) > 0 {
+		return "", hashtags
+	}
+
+	trimmed := strings.TrimSpace(search)
+	if strings.HasPrefix(trimmed, "#") {
+		return strings.TrimLeft(trimmed, "#"), targetTags
+	}
+
+	return search, targetTags
+}
+
+func applyTagFilters(
+	query *gorm.DB,
+	search string,
+	targetTags []string,
+	requestedTagsFilteredOut bool,
+) *gorm.DB {
+	query = query.Where("tag NOT LIKE ?", "%+%")
+
+	if requestedTagsFilteredOut {
+		return query.Where("1 = 0")
+	}
+	if len(targetTags) > 0 {
+		return query.Where("tag IN ?", targetTags)
+	}
+	if search != "" {
+		return query.Where("tag LIKE ?", "%"+search+"%")
+	}
+
+	return query
+}
+
+func collectTagIDs(tags []models.Tag) []string {
+	tagIDs := make([]string, len(tags))
+	for i, tag := range tags {
+		tagIDs[i] = tag.ID
+	}
+
+	return tagIDs
+}
+
+func buildTagMetrics(tag models.Tag, snapshots map[string]models.TagHistory, endDate *time.Time) tagMetrics {
+	metrics := tagMetrics{
+		ViewCount: tag.ViewCount,
+		PostCount: tag.PostCount,
+	}
+
+	if snapshot, ok := snapshots[tag.ID]; ok {
+		metrics.ViewCount = snapshot.ViewCount
+		metrics.PostCount = snapshot.PostCount
+	}
+	if tagDeletedByRangeEnd(tag, endDate) {
+		metrics.ViewCount = 0
+	}
+
+	metrics.Ratio = utils.CalculateRatio(metrics.ViewCount, metrics.PostCount)
+	return metrics
+}
+
+func buildTagHistoryPoints(history []models.TagHistory) []HistoryPoint {
+	historyPoints := make([]HistoryPoint, len(history))
+	for i, point := range history {
+		historyPoint := HistoryPoint{
+			ID:              point.ID,
+			TagID:           point.TagID,
+			ViewCount:       point.ViewCount,
+			Change:          0,
+			PostCount:       point.PostCount,
+			Ratio:           utils.CalculateRatio(point.ViewCount, point.PostCount),
+			PostCountChange: 0,
+			CreatedAt:       point.CreatedAt.Unix(),
+			UpdatedAt:       point.UpdatedAt.Unix(),
+			ChangePercent:   0,
+		}
+
+		if i < len(history)-1 {
+			previousPoint := history[i+1]
+			viewChange := point.ViewCount - previousPoint.ViewCount
+			historyPoint.Change = viewChange
+			historyPoint.PostCountChange = point.PostCount - previousPoint.PostCount
+			if previousPoint.ViewCount > 0 {
+				historyPoint.ChangePercent = float64(viewChange) / float64(previousPoint.ViewCount) * 100
+			}
+		}
+
+		historyPoints[i] = historyPoint
+	}
+
+	return historyPoints
+}
+
+func buildTagWithHistory(
+	tag models.Tag,
+	snapshots map[string]models.TagHistory,
+	history []models.TagHistory,
+	endDate *time.Time,
+) TagWithHistory {
+	metrics := buildTagMetrics(tag, snapshots, endDate)
+	tagWithHistory := TagWithHistory{
+		ID:                   tag.ID,
+		Tag:                  tag.Tag,
+		ViewCount:            metrics.ViewCount,
+		PostCount:            metrics.PostCount,
+		Ratio:                metrics.Ratio,
+		Rank:                 tag.Rank,
+		Heat:                 0,
+		FanslyCreatedAt:      ptr(timeToUnix(tag.FanslyCreatedAt)),
+		LastCheckedAt:        timeToUnixPtr(tag.LastCheckedAt),
+		LastUsedForDiscovery: timeToUnixPtr(tag.LastUsedForDiscovery),
+		IsDeleted:            tag.IsDeleted,
+		DeletedDetectedAt:    timeToUnixPtr(tag.DeletedDetectedAt),
+		CreatedAt:            tag.CreatedAt.Unix(),
+		UpdatedAt:            tag.UpdatedAt.Unix(),
+		History:              buildTagHistoryPoints(history),
+	}
+
+	if len(history) > 0 {
+		tagWithHistory.TotalChange = history[0].ViewCount - history[len(history)-1].ViewCount
+	}
+
+	return tagWithHistory
+}
+
+func buildTagsWithHistory(
+	tags []models.Tag,
+	snapshots map[string]models.TagHistory,
+	historyByTag map[string][]models.TagHistory,
+	endDate *time.Time,
+) []TagWithHistory {
+	tagsWithHistory := make([]TagWithHistory, 0, len(tags))
+	for _, tag := range tags {
+		tagsWithHistory = append(
+			tagsWithHistory,
+			buildTagWithHistory(tag, snapshots, historyByTag[tag.ID], endDate),
+		)
+	}
+
+	return tagsWithHistory
+}
+
+func buildTagData(
+	tags []models.Tag,
+	snapshots map[string]models.TagHistory,
+	endDate *time.Time,
+) []map[string]any {
+	tagsData := make([]map[string]any, len(tags))
+	for i, tag := range tags {
+		metrics := buildTagMetrics(tag, snapshots, endDate)
+		tagsData[i] = map[string]any{
+			"id":                   tag.ID,
+			"tag":                  tag.Tag,
+			"viewCount":            metrics.ViewCount,
+			"postCount":            metrics.PostCount,
+			"ratio":                metrics.Ratio,
+			"rank":                 tag.Rank,
+			"heat":                 0,
+			"fanslyCreatedAt":      ptr(timeToUnix(tag.FanslyCreatedAt)),
+			"lastCheckedAt":        timeToUnixPtr(tag.LastCheckedAt),
+			"lastUsedForDiscovery": timeToUnixPtr(tag.LastUsedForDiscovery),
+			"isDeleted":            tag.IsDeleted,
+			"deletedDetectedAt":    timeToUnixPtr(tag.DeletedDetectedAt),
+			"createdAt":            tag.CreatedAt.Unix(),
+			"updatedAt":            tag.UpdatedAt.Unix(),
+		}
+	}
+
+	return tagsData
+}
+
+func (h *TagHandler) applyTagSort(
+	query *gorm.DB,
+	sortBy string,
+	sortOrder string,
+	endDate *time.Time,
+) *gorm.DB {
+	if sortBy != "ratio" {
+		return query.Order("rank " + sortOrder)
+	}
+
+	orderClause := "(CASE WHEN tags.post_count > 0 THEN tags.view_count / tags.post_count ELSE 0 END) " + sortOrder
+	if endDate != nil {
+		orderClause = "(CASE WHEN COALESCE(tag_snapshots.post_count, tags.post_count) > 0 THEN COALESCE(tag_snapshots.view_count, tags.view_count) / COALESCE(tag_snapshots.post_count, tags.post_count) ELSE 0 END) " + sortOrder
+		query = query.Joins("LEFT JOIN (?) AS tag_snapshots ON tag_snapshots.tag_id = tags.id", latestTagSnapshotQuery(h.db, *endDate))
+	}
+
+	return query.Order(orderClause).Order("rank ASC")
+}
+
+func (h *TagHandler) loadTagSnapshotsForRange(
+	tagIDs []string,
+	endDate *time.Time,
+) (map[string]models.TagHistory, error) {
+	if endDate == nil {
+		return map[string]models.TagHistory{}, nil
+	}
+
+	return loadTagSnapshots(h.db, tagIDs, *endDate)
+}
+
+func (h *TagHandler) loadTagHistoryByTag(
+	tagIDs []string,
+	startDate *time.Time,
+	endDate *time.Time,
+) (map[string][]models.TagHistory, error) {
+	historyByTag := make(map[string][]models.TagHistory)
+	if len(tagIDs) == 0 {
+		return historyByTag, nil
+	}
+
+	const batchSize = 1000
+	for i := 0; i < len(tagIDs); i += batchSize {
+		end := min(i+batchSize, len(tagIDs))
+		batchIDs := tagIDs[i:end]
+
+		histQuery := h.db.Model(&models.TagHistory{}).
+			Where("tag_id IN ?", batchIDs).
+			Order("tag_id, created_at DESC")
+
+		if startDate != nil {
+			histQuery = histQuery.Where("created_at >= ?", *startDate)
+		}
+		if endDate != nil {
+			histQuery = histQuery.Where("created_at <= ?", *endDate)
+		}
+
+		var batchHistories []models.TagHistory
+		if err := histQuery.Find(&batchHistories).Error; err != nil {
+			return nil, err
+		}
+
+		for _, history := range batchHistories {
+			historyByTag[history.TagID] = append(historyByTag[history.TagID], history)
+		}
+	}
+
+	return historyByTag, nil
+}
+
+func latestTagSnapshotQuery(db *gorm.DB, endDate time.Time) *gorm.DB {
+	latestIDs := db.Model(&models.TagHistory{}).
+		Select("tag_id, MAX(id) AS id").
+		Where("created_at <= ?", endDate).
+		Group("tag_id")
+
+	return db.Table("tag_history AS th").
+		Select("th.id, th.tag_id, th.view_count, th.change, th.post_count, th.post_count_change, th.created_at, th.updated_at").
+		Joins("JOIN (?) AS latest ON latest.id = th.id", latestIDs)
+}
+
+func loadTagSnapshots(db *gorm.DB, tagIDs []string, endDate time.Time) (map[string]models.TagHistory, error) {
+	if len(tagIDs) == 0 {
+		return map[string]models.TagHistory{}, nil
+	}
+
+	var snapshots []models.TagHistory
+	if err := db.Table("(?) AS tag_snapshots", latestTagSnapshotQuery(db, endDate)).
+		Where("tag_id IN ?", tagIDs).
+		Scan(&snapshots).Error; err != nil {
+		return nil, err
+	}
+
+	snapshotByTag := make(map[string]models.TagHistory, len(snapshots))
+	for _, snapshot := range snapshots {
+		snapshotByTag[snapshot.TagID] = snapshot
+	}
+
+	return snapshotByTag, nil
+}
+
+func scoreRelatedTags(rows []relatedTagAggregate, inputCount int) []relatedTagScore {
+	numInputs := float64(inputCount)
+	scoredRows := make([]relatedTagScore, 0, len(rows))
+
+	for _, row := range rows {
+		normAvg := 0.0
+		coverage := 0.0
+		if numInputs > 0 {
+			normAvg = row.NormSum / numInputs
+			coverage = float64(row.CoverageCnt) / numInputs
+		}
+
+		postCount := float64(row.RPostCount)
+		if postCount < 0 {
+			postCount = 0
+		}
+		if postCount > 50000 {
+			postCount = 50000
+		}
+
+		popBoost := 1.0
+		logValue := math.Log1p(postCount)
+		if logValue > 0 {
+			popBoost = math.Pow(logValue, 0.2)
+		}
+
+		scoredRows = append(scoredRows, relatedTagScore{
+			ID:         row.ID,
+			Tag:        row.Tag,
+			NormAvg:    normAvg,
+			Coverage:   coverage,
+			FinalScore: normAvg * coverage * popBoost,
+		})
+	}
+
+	return scoredRows
+}
+
+func tagDeletedByRangeEnd(tag models.Tag, endDate *time.Time) bool {
+	if !tag.IsDeleted {
+		return false
+	}
+	if endDate == nil || tag.DeletedDetectedAt == nil {
+		return true
+	}
+	return !tag.DeletedDetectedAt.After(*endDate)
 }
 
 func timeToUnix(t time.Time) int64 {
@@ -754,5 +924,5 @@ func timeToUnix(t time.Time) int64 {
 
 //go:fix inline
 func ptr[T any](v T) *T {
-	return new(v)
+	return &v
 }

--- a/backend-go/utils/tag_metrics.go
+++ b/backend-go/utils/tag_metrics.go
@@ -1,0 +1,15 @@
+package utils
+
+import "strings"
+
+func CalculateRatio(viewCount, postCount int64) float64 {
+	if postCount <= 0 {
+		return 0
+	}
+
+	return float64(viewCount) / float64(postCount)
+}
+
+func TagNameHasPlus(tag string) bool {
+	return strings.Contains(strings.TrimSpace(tag), "+")
+}

--- a/backend-go/utils/utils.go
+++ b/backend-go/utils/utils.go
@@ -16,11 +16,17 @@ func CalculateTagRanks(db *gorm.DB) error {
 				id,
 				DENSE_RANK() OVER (ORDER BY CASE WHEN is_deleted THEN 0 ELSE view_count END DESC, created_at ASC) as new_rank
 			FROM tags
+			WHERE tag NOT LIKE '%+%'
 		) t2 ON t1.id = t2.id
 		SET t1.rank = t2.new_rank
 	`
 
-	return db.Exec(sql).Error
+	if err := db.Exec(sql).Error; err != nil {
+		return err
+	}
+
+	clearSQL := `UPDATE tags SET rank = NULL WHERE tag LIKE '%+%'`
+	return db.Exec(clearSQL).Error
 }
 
 // CalculateCreatorRanks recalculates ranks for all creators

--- a/backend-go/workers/statistics_calculator.go
+++ b/backend-go/workers/statistics_calculator.go
@@ -60,6 +60,7 @@ func (w *StatisticsCalculatorWorker) calculateTagStatistics(ctx context.Context)
 	var totalViewCount, totalPostCount int64
 	if err := tx.Model(&models.Tag{}).
 		Where("is_deleted = ?", false).
+		Where("tag NOT LIKE ?", "%+%").
 		Select("COALESCE(SUM(view_count), 0), COALESCE(SUM(post_count), 0)").
 		Row().Scan(&totalViewCount, &totalPostCount); err != nil {
 		tx.Rollback()

--- a/backend-go/workers/tag_cleanup.go
+++ b/backend-go/workers/tag_cleanup.go
@@ -49,7 +49,7 @@ func (w *TagCleanupWorker) Run(ctx context.Context) error {
 
 		var tagIDs []string
 		if err := w.db.Model(&models.Tag{}).
-			Where("view_count < ?", w.minViews).
+			Where("view_count < ? OR tag LIKE ?", w.minViews, "%+%").
 			Order("id").
 			Limit(w.batchSize).
 			Pluck("id", &tagIDs).Error; err != nil {

--- a/backend-go/workers/tag_discovery.go
+++ b/backend-go/workers/tag_discovery.go
@@ -7,6 +7,7 @@ import (
 	"ftoolbox/config"
 	"ftoolbox/fansly"
 	"ftoolbox/models"
+	"ftoolbox/utils"
 	"strings"
 	"time"
 
@@ -157,6 +158,7 @@ func (w *TagDiscoveryWorker) getTagForDiscovery() (string, error) {
 	// Get multiple tags that haven't been used recently and aren't deleted, ordered by rank
 	if err := w.db.Where("(last_used_for_discovery IS NULL OR last_used_for_discovery < ?) AND is_deleted = ?", hoursAgo, false).
 		Where("tag NOT LIKE ?", "%&%").
+		Where("tag NOT LIKE ?", "%+%").
 		Order("rank ASC").
 		Limit(10).
 		Find(&tags).Error; err == nil && len(tags) > 0 {
@@ -181,10 +183,8 @@ func (w *TagDiscoveryWorker) extractTagsFromSuggestions(suggestions []fansly.Med
 
 	for _, suggestion := range suggestions {
 		for _, tag := range suggestion.PostTags {
-			// Use the tag name as key to ensure uniqueness
 			tagName := strings.ToLower(strings.TrimSpace(tag.Tag))
-			// Ignore tags that contain '&' as Fansly truncates them before '&'
-			if tagName != "" && !strings.Contains(tagName, "&") {
+			if !shouldSkipDiscoveredTagName(tagName) {
 				tagMap[tagName] = tag
 			}
 		}
@@ -200,8 +200,7 @@ func (w *TagDiscoveryWorker) extractTagsFromSuggestions(suggestions []fansly.Med
 }
 
 func (w *TagDiscoveryWorker) processDiscoveredTag(tag fansly.FanslyTag) error {
-	// Ignore tags that contain '&' as Fansly truncates them before '&'
-	if strings.Contains(tag.Tag, "&") {
+	if shouldSkipDiscoveredTagName(tag.Tag) {
 		return nil
 	}
 	// Check if tag already exists
@@ -252,8 +251,8 @@ func (w *TagDiscoveryWorker) updateTagRelationsFromSuggestions(ctx context.Conte
 		// Build a unique set of tag IDs observed in this suggestion
 		seen := make(map[string]struct{})
 		for _, t := range s.PostTags {
-			// Skip tags that contain '&' to avoid polluted relations
-			if strings.Contains(strings.ToLower(strings.TrimSpace(t.Tag)), "&") {
+			tagName := strings.ToLower(strings.TrimSpace(t.Tag))
+			if shouldSkipDiscoveredTagName(tagName) {
 				continue
 			}
 			id := strings.TrimSpace(t.ID)
@@ -327,4 +326,8 @@ func (w *TagDiscoveryWorker) purgeOldTagRelations(windowDays int) error {
 	}
 	// Recalculate tag ranks/heat only if needed; not required for relations
 	return nil
+}
+
+func shouldSkipDiscoveredTagName(tagName string) bool {
+	return tagName == "" || strings.Contains(tagName, "&") || utils.TagNameHasPlus(tagName)
 }

--- a/backend-go/workers/tag_updater.go
+++ b/backend-go/workers/tag_updater.go
@@ -37,6 +37,7 @@ func (w *TagUpdaterWorker) Run(ctx context.Context) error {
 
 	var tags []models.Tag
 	if err := w.db.Where("last_checked_at IS NULL OR last_checked_at < ?", twentyFourHoursAgo).
+		Where("tag NOT LIKE ?", "%+%").
 		Order("view_count DESC").
 		Limit(20).
 		Find(&tags).Error; err != nil {

--- a/frontend/src/lib/components/TagHistory.svelte
+++ b/frontend/src/lib/components/TagHistory.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { Card, CardContent, CardHeader, CardTitle } from '$lib/components/ui/card';
   import Chart from 'chart.js/auto';
+  import type { ChartConfiguration, ChartDataset } from 'chart.js';
   import 'chartjs-adapter-date-fns';
 
   interface HistoryPoint {
@@ -11,22 +12,29 @@
     change: number;
     changePercent: number;
     postCount: number;
+    ratio: number;
     postCountChange: number;
     createdAt: Date | string | number;
     updatedAt: Date | string | number;
+  }
+
+  interface HistoryPointWithDates extends Omit<HistoryPoint, 'createdAt' | 'updatedAt'> {
+    createdAt: Date;
+    updatedAt: Date;
   }
 
   interface Props {
     history?: HistoryPoint[];
   }
 
+  type ChartPoint = { x: Date; y: number };
+
   const { history = [] }: Props = $props();
   let chartCanvas = $state<HTMLCanvasElement>();
-  let chartInstance: Chart | null = null;
+  let chartInstance: Chart<'line', ChartPoint[]> | null = null;
   let chartInitialized = false;
 
-  // Convert dates in history to Date objects
-  const historyWithDates = $derived(
+  const historyWithDates = $derived<HistoryPointWithDates[]>(
     history.map((point) => ({
       ...point,
       createdAt:
@@ -40,12 +48,25 @@
     }))
   );
 
-  // Update chart when history changes
   $effect(() => {
-    if (historyWithDates.length > 0) {
+    if (chartCanvas) {
       setTimeout(() => updateChart(), 0);
     }
   });
+
+  function buildSeries(
+    metric: keyof Pick<
+      HistoryPointWithDates,
+      'viewCount' | 'change' | 'postCount' | 'ratio' | 'postCountChange'
+    >
+  ): ChartPoint[] {
+    return historyWithDates
+      .map((point) => ({
+        x: point.createdAt,
+        y: point[metric]
+      }))
+      .reverse();
+  }
 
   function updateChart() {
     if (!chartCanvas) {
@@ -57,286 +78,307 @@
       chartInstance = null;
     }
 
-    // Always create chart data, even if empty
-    const viewCountData =
-      historyWithDates.length > 0
-        ? historyWithDates
-            .map((point) => ({
-              x: point.createdAt,
-              y: point.viewCount
-            }))
-            .reverse()
-        : [];
+    const datasets: ChartDataset<'line', ChartPoint[]>[] = [
+      {
+        label: 'View Count',
+        data: buildSeries('viewCount'),
+        borderColor: 'rgb(99, 102, 241)',
+        backgroundColor: 'rgba(99, 102, 241, 0.1)',
+        fill: true,
+        tension: 0.4,
+        pointRadius: 0,
+        pointHoverRadius: 6,
+        pointBackgroundColor: 'rgb(99, 102, 241)',
+        pointBorderColor: '#fff',
+        pointBorderWidth: 2,
+        pointHoverBackgroundColor: 'rgb(99, 102, 241)',
+        pointHoverBorderColor: '#fff',
+        pointHoverBorderWidth: 2,
+        yAxisID: 'y'
+      },
+      {
+        label: 'Views Change',
+        data: buildSeries('change'),
+        borderColor: 'rgb(52, 211, 153)',
+        backgroundColor: 'rgba(52, 211, 153, 0.15)',
+        fill: false,
+        tension: 0.4,
+        pointRadius: 0,
+        pointHoverRadius: 6,
+        pointBackgroundColor: 'rgb(52, 211, 153)',
+        pointBorderColor: '#fff',
+        pointBorderWidth: 2,
+        pointHoverBackgroundColor: 'rgb(52, 211, 153)',
+        pointHoverBorderColor: '#fff',
+        pointHoverBorderWidth: 2,
+        borderDash: [4, 4],
+        hidden: true,
+        yAxisID: 'y1'
+      },
+      {
+        label: 'Post Count',
+        data: buildSeries('postCount'),
+        borderColor: 'rgb(251, 146, 60)',
+        backgroundColor: 'rgba(251, 146, 60, 0.1)',
+        fill: true,
+        tension: 0.4,
+        pointRadius: 0,
+        pointHoverRadius: 6,
+        pointBackgroundColor: 'rgb(251, 146, 60)',
+        pointBorderColor: '#fff',
+        pointBorderWidth: 2,
+        pointHoverBackgroundColor: 'rgb(251, 146, 60)',
+        pointHoverBorderColor: '#fff',
+        pointHoverBorderWidth: 2,
+        yAxisID: 'y2'
+      },
+      {
+        label: 'Ratio',
+        data: buildSeries('ratio'),
+        borderColor: 'rgb(236, 72, 153)',
+        backgroundColor: 'rgba(236, 72, 153, 0.12)',
+        fill: false,
+        tension: 0.4,
+        pointRadius: 0,
+        pointHoverRadius: 6,
+        pointBackgroundColor: 'rgb(236, 72, 153)',
+        pointBorderColor: '#fff',
+        pointBorderWidth: 2,
+        pointHoverBackgroundColor: 'rgb(236, 72, 153)',
+        pointHoverBorderColor: '#fff',
+        pointHoverBorderWidth: 2,
+        yAxisID: 'y3'
+      },
+      {
+        label: 'Post Change',
+        data: buildSeries('postCountChange'),
+        borderColor: 'rgb(14, 165, 233)',
+        backgroundColor: 'rgba(14, 165, 233, 0.12)',
+        fill: false,
+        tension: 0.4,
+        pointRadius: 0,
+        pointHoverRadius: 6,
+        pointBackgroundColor: 'rgb(14, 165, 233)',
+        pointBorderColor: '#fff',
+        pointBorderWidth: 2,
+        pointHoverBackgroundColor: 'rgb(14, 165, 233)',
+        pointHoverBorderColor: '#fff',
+        pointHoverBorderWidth: 2,
+        borderDash: [8, 4],
+        hidden: true,
+        yAxisID: 'y1'
+      }
+    ];
 
-    // Create change data for secondary axis
-    const changeData =
-      historyWithDates.length > 0
-        ? historyWithDates
-            .map((point) => ({
-              x: point.createdAt,
-              y: point.change
-            }))
-            .reverse()
-        : [];
-
-    // Create post count data
-    const postCountData =
-      historyWithDates.length > 0
-        ? historyWithDates
-            .map((point) => ({
-              x: point.createdAt,
-              y: point.postCount
-            }))
-            .reverse()
-        : [];
-
-    // Check if we have any non-zero change values
-    const hasChangeData = changeData.some((d) => d.y !== 0);
-
-    try {
-      chartInstance = new Chart(chartCanvas, {
-        type: 'line',
-        data: {
-          datasets: [
-            {
-              label: 'View Count',
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              data: viewCountData as any,
-              borderColor: 'rgb(99, 102, 241)',
-              backgroundColor: 'rgba(99, 102, 241, 0.1)',
-              fill: true,
-              tension: 0.4,
-              pointRadius: 0,
-              pointHoverRadius: 6,
-              pointBackgroundColor: 'rgb(99, 102, 241)',
-              pointBorderColor: '#fff',
-              pointBorderWidth: 2,
-              pointHoverBackgroundColor: 'rgb(99, 102, 241)',
-              pointHoverBorderColor: '#fff',
-              pointHoverBorderWidth: 2,
-              yAxisID: 'y'
-            },
-            ...(hasChangeData
-              ? [
-                  {
-                    label: 'Change',
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    data: changeData as any,
-                    borderColor: 'var(--chart-2, rgb(52, 211, 153))',
-                    backgroundColor: 'rgba(52, 211, 153, 0.15)',
-                    fill: false,
-                    tension: 0.4,
-                    pointRadius: 0,
-                    pointHoverRadius: 6,
-                    pointBackgroundColor: 'var(--chart-2, rgb(52, 211, 153))',
-                    pointBorderColor: '#fff',
-                    pointBorderWidth: 2,
-                    pointHoverBackgroundColor: 'var(--chart-2, rgb(52, 211, 153))',
-                    pointHoverBorderColor: '#fff',
-                    pointHoverBorderWidth: 2,
-                    borderDash: [4, 4],
-                    yAxisID: 'y1'
-                  }
-                ]
-              : []),
-            {
-              label: 'Post Count',
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              data: postCountData as any,
-              borderColor: 'rgb(251, 146, 60)',
-              backgroundColor: 'rgba(251, 146, 60, 0.1)',
-              fill: true,
-              tension: 0.4,
-              pointRadius: 0,
-              pointHoverRadius: 6,
-              pointBackgroundColor: 'rgb(251, 146, 60)',
-              pointBorderColor: '#fff',
-              pointBorderWidth: 2,
-              pointHoverBackgroundColor: 'rgb(251, 146, 60)',
-              pointHoverBorderColor: '#fff',
-              pointHoverBorderWidth: 2,
-              yAxisID: 'y2'
-            }
-          ]
+    const chartConfig: ChartConfiguration<'line', ChartPoint[]> = {
+      type: 'line',
+      data: {
+        datasets
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        interaction: {
+          mode: 'index',
+          intersect: false
         },
-        options: {
-          responsive: true,
-          maintainAspectRatio: false,
-          interaction: {
-            mode: 'index',
-            intersect: false
-          },
-          plugins: {
-            legend: {
-              display: true,
-              position: 'top' as const,
-              labels: {
-                usePointStyle: true,
-                padding: 20,
-                font: {
-                  size: 12
-                }
-              }
-            },
-            tooltip: {
-              backgroundColor: 'rgba(0, 0, 0, 0.8)',
-              titleColor: '#fff',
-              bodyColor: '#fff',
-              borderColor: 'rgb(99, 102, 241)',
-              borderWidth: 1,
-              padding: 12,
-              displayColors: true,
-              callbacks: {
-                label: function (context) {
-                  const label = context.dataset.label || '';
-                  const value = context.parsed.y;
-                  if (value === null) {
-                    return label + ': N/A';
-                  }
-                  if (label === 'Change') {
-                    const formatted = new Intl.NumberFormat('en-US', {
-                      signDisplay: 'exceptZero'
-                    }).format(value);
-                    return label + ': ' + formatted;
-                  }
-                  return label + ': ' + new Intl.NumberFormat().format(value);
-                }
+        plugins: {
+          legend: {
+            display: true,
+            position: 'top',
+            labels: {
+              usePointStyle: true,
+              padding: 20,
+              font: {
+                size: 12
               }
             }
           },
-          scales: {
-            x: {
-              type: 'time',
-              time: {
-                unit: 'day',
-                displayFormats: {
-                  day: 'MMM d'
+          tooltip: {
+            backgroundColor: 'rgba(0, 0, 0, 0.8)',
+            titleColor: '#fff',
+            bodyColor: '#fff',
+            borderColor: 'rgb(99, 102, 241)',
+            borderWidth: 1,
+            padding: 12,
+            displayColors: true,
+            callbacks: {
+              label: (context) => {
+                const label = context.dataset.label || '';
+                const value = context.parsed.y;
+                if (value === null) {
+                  return `${label}: N/A`;
                 }
-              },
-              grid: {
-                color: 'rgba(0, 0, 0, 0.05)',
-                display: true
-              },
-              border: {
-                display: false
-              },
-              ticks: {
-                color: 'rgb(107, 114, 128)',
-                font: {
-                  size: 11
+                if (label === 'Ratio') {
+                  return `${label}: ${value.toFixed(2)}`;
                 }
+                if (label === 'Views Change' || label === 'Post Change') {
+                  const formatted = new Intl.NumberFormat('en-US', {
+                    signDisplay: 'exceptZero'
+                  }).format(value);
+                  return `${label}: ${formatted}`;
+                }
+                return `${label}: ${new Intl.NumberFormat().format(value)}`;
+              }
+            }
+          }
+        },
+        scales: {
+          x: {
+            type: 'time',
+            time: {
+              unit: 'day',
+              displayFormats: {
+                day: 'MMM d'
               }
             },
-            y: {
-              type: 'linear',
-              display: true,
-              position: 'left',
-              beginAtZero: false,
-              grid: {
-                color: 'rgba(0, 0, 0, 0.05)',
-                display: true
-              },
-              border: {
-                display: false
-              },
-              ticks: {
-                color: 'rgb(107, 114, 128)',
-                font: {
-                  size: 11
-                },
-                callback: function (value) {
-                  return new Intl.NumberFormat('en-US', {
-                    notation: 'compact',
-                    compactDisplay: 'short'
-                  }).format(value as number);
-                }
-              },
-              title: {
-                display: true,
-                text: 'View Count',
-                color: 'rgb(107, 114, 128)',
-                font: {
-                  size: 12
-                }
-              }
+            grid: {
+              color: 'rgba(0, 0, 0, 0.05)',
+              display: true
             },
-            ...(hasChangeData
-              ? {
-                  y1: {
-                    type: 'linear',
-                    display: true,
-                    position: 'right',
-                    beginAtZero: false,
-                    grid: {
-                      drawOnChartArea: false
-                    },
-                    border: {
-                      display: false
-                    },
-                    ticks: {
-                      color: 'rgb(107, 114, 128)',
-                      font: {
-                        size: 11
-                      },
-                      callback: function (value) {
-                        return new Intl.NumberFormat('en-US', {
-                          signDisplay: 'exceptZero'
-                        }).format(value as number);
-                      }
-                    },
-                    title: {
-                      display: true,
-                      text: 'Views Change',
-                      color: 'rgb(107, 114, 128)',
-                      font: {
-                        size: 12
-                      }
-                    }
-                  }
-                }
-              : {}),
-            y2: {
-              type: 'linear',
+            border: {
+              display: false
+            },
+            ticks: {
+              color: 'rgb(107, 114, 128)',
+              font: {
+                size: 11
+              }
+            }
+          },
+          y: {
+            type: 'linear',
+            display: true,
+            position: 'left',
+            beginAtZero: false,
+            grid: {
+              color: 'rgba(0, 0, 0, 0.05)',
+              display: true
+            },
+            border: {
+              display: false
+            },
+            ticks: {
+              color: 'rgb(107, 114, 128)',
+              font: {
+                size: 11
+              },
+              callback: (value) =>
+                new Intl.NumberFormat('en-US', {
+                  notation: 'compact',
+                  compactDisplay: 'short'
+                }).format(Number(value))
+            },
+            title: {
               display: true,
-              position: 'right',
-              beginAtZero: false,
-              grid: {
-                drawOnChartArea: false
+              text: 'View Count',
+              color: 'rgb(107, 114, 128)',
+              font: {
+                size: 12
+              }
+            }
+          },
+          y1: {
+            type: 'linear',
+            display: true,
+            position: 'right',
+            beginAtZero: false,
+            grid: {
+              drawOnChartArea: false
+            },
+            border: {
+              display: false
+            },
+            ticks: {
+              color: 'rgb(52, 211, 153)',
+              font: {
+                size: 11
               },
-              border: {
-                display: false
+              callback: (value) =>
+                new Intl.NumberFormat('en-US', {
+                  signDisplay: 'exceptZero'
+                }).format(Number(value))
+            },
+            title: {
+              display: true,
+              text: 'Changes',
+              color: 'rgb(52, 211, 153)',
+              font: {
+                size: 12
+              }
+            }
+          },
+          y2: {
+            type: 'linear',
+            display: true,
+            position: 'right',
+            beginAtZero: false,
+            grid: {
+              drawOnChartArea: false
+            },
+            border: {
+              display: false
+            },
+            ticks: {
+              color: 'rgb(251, 146, 60)',
+              font: {
+                size: 11
               },
-              ticks: {
-                color: 'rgb(251, 146, 60)',
-                font: {
-                  size: 11
-                },
-                callback: function (value) {
-                  return new Intl.NumberFormat('en-US', {
-                    notation: 'compact',
-                    compactDisplay: 'short'
-                  }).format(value as number);
-                }
+              callback: (value) =>
+                new Intl.NumberFormat('en-US', {
+                  notation: 'compact',
+                  compactDisplay: 'short'
+                }).format(Number(value))
+            },
+            title: {
+              display: true,
+              text: 'Post Count',
+              color: 'rgb(251, 146, 60)',
+              font: {
+                size: 12
+              }
+            }
+          },
+          y3: {
+            type: 'linear',
+            display: true,
+            position: 'right',
+            offset: true,
+            beginAtZero: false,
+            grid: {
+              drawOnChartArea: false
+            },
+            border: {
+              display: false
+            },
+            ticks: {
+              color: 'rgb(236, 72, 153)',
+              font: {
+                size: 11
               },
-              title: {
-                display: true,
-                text: 'Post Count',
-                color: 'rgb(251, 146, 60)',
-                font: {
-                  size: 12
-                }
+              callback: (value) => Number(value).toFixed(2)
+            },
+            title: {
+              display: true,
+              text: 'Ratio',
+              color: 'rgb(236, 72, 153)',
+              font: {
+                size: 12
               }
             }
           }
         }
-      });
+      }
+    };
+
+    try {
+      chartInstance = new Chart(chartCanvas, chartConfig);
       chartInitialized = true;
     } catch (error) {
       console.error('Failed to create chart:', error);
     }
   }
 
-  // Watch for canvas element to be available
   $effect(() => {
     if (chartCanvas && !chartInitialized) {
       chartInitialized = true;
@@ -364,6 +406,14 @@
 
   function formatNumber(num: number): string {
     return new Intl.NumberFormat().format(num);
+  }
+
+  function formatRatio(ratio: number, postCount: number): string {
+    if (postCount <= 0) {
+      return '-';
+    }
+
+    return ratio.toFixed(2);
   }
 </script>
 
@@ -393,6 +443,7 @@
                   <th class="py-2 text-right">View Count</th>
                   <th class="py-2 text-right">Views Change</th>
                   <th class="py-2 text-right">Post Count</th>
+                  <th class="py-2 text-right">Ratio</th>
                   <th class="py-2 text-right">Post Change</th>
                 </tr>
               </thead>
@@ -417,6 +468,7 @@
                       {/if}
                     </td>
                     <td class="py-2 text-right">{formatNumber(point.postCount)}</td>
+                    <td class="py-2 text-right">{formatRatio(point.ratio, point.postCount)}</td>
                     <td class="py-2 text-right">
                       {#if point.postCountChange !== 0}
                         <span

--- a/frontend/src/routes/tags/+page.svelte
+++ b/frontend/src/routes/tags/+page.svelte
@@ -143,11 +143,15 @@
     goto(`?${params}`);
   }
 
-  function toggleRankSort() {
+  function toggleSort(sortBy: 'rank' | 'ratio') {
     const params = new SvelteURLSearchParams($page.url.searchParams);
     const currentSortOrder = params.get('sortOrder') || 'asc';
-    params.set('sortBy', 'rank');
-    params.set('sortOrder', currentSortOrder === 'desc' ? 'asc' : 'desc');
+    const currentSortBy = params.get('sortBy') || 'rank';
+    params.set('sortBy', sortBy);
+    params.set(
+      'sortOrder',
+      currentSortBy === sortBy && currentSortOrder === 'desc' ? 'asc' : 'desc'
+    );
     params.set('page', '1');
     goto(`?${params}`);
   }
@@ -172,6 +176,14 @@
 
   function formatNumber(num: number): string {
     return new Intl.NumberFormat().format(num);
+  }
+
+  function formatRatio(ratio: number, postCount: number): string {
+    if (postCount <= 0) {
+      return '-';
+    }
+
+    return ratio.toFixed(2);
   }
 
   function formatDate(date: Date | string | number | null | undefined): string {
@@ -387,19 +399,36 @@
                 <TableHead class="w-16">
                   <button
                     class="hover:text-foreground flex items-center gap-1 transition-colors"
-                    onclick={toggleRankSort}
+                    onclick={() => toggleSort('rank')}
                   >
                     Rank
-                    {#if data.sortOrder === 'desc'}
-                      <ArrowDown class="h-4 w-4" />
-                    {:else}
-                      <ArrowUp class="h-4 w-4" />
+                    {#if data.sortBy === 'rank'}
+                      {#if data.sortOrder === 'desc'}
+                        <ArrowDown class="h-4 w-4" />
+                      {:else}
+                        <ArrowUp class="h-4 w-4" />
+                      {/if}
                     {/if}
                   </button>
                 </TableHead>
                 <TableHead>Tag</TableHead>
                 <TableHead>View Count</TableHead>
                 <TableHead>Post Count</TableHead>
+                <TableHead>
+                  <button
+                    class="hover:text-foreground flex items-center gap-1 transition-colors"
+                    onclick={() => toggleSort('ratio')}
+                  >
+                    Ratio
+                    {#if data.sortBy === 'ratio'}
+                      {#if data.sortOrder === 'desc'}
+                        <ArrowDown class="h-4 w-4" />
+                      {:else}
+                        <ArrowUp class="h-4 w-4" />
+                      {/if}
+                    {/if}
+                  </button>
+                </TableHead>
                 <TableHead>Views Change</TableHead>
                 <TableHead>Last Updated</TableHead>
               </TableRow>
@@ -444,6 +473,7 @@
                   </TableCell>
                   <TableCell>{formatNumber(tag.viewCount)}</TableCell>
                   <TableCell>{formatNumber(tag.postCount || 0)}</TableCell>
+                  <TableCell>{formatRatio(tag.ratio || 0, tag.postCount || 0)}</TableCell>
                   <TableCell>
                     {#if change !== 0}
                       <div class="flex items-center gap-1">
@@ -469,7 +499,7 @@
                 </TableRow>
                 {#if expandedTagId === tag.id}
                   <TableRow>
-                    <TableCell colspan={7} class="p-0">
+                    <TableCell colspan={8} class="p-0">
                       <div class="bg-muted/50 p-6">
                         <TagHistory history={tag.history} />
                       </div>

--- a/frontend/src/routes/tags/+page.ts
+++ b/frontend/src/routes/tags/+page.ts
@@ -8,6 +8,7 @@ interface TagHistory {
   change: number;
   changePercent: number;
   postCount: number;
+  ratio: number;
   postCountChange: number;
   createdAt: Date;
   updatedAt: Date;
@@ -18,6 +19,7 @@ interface Tag {
   tag: string;
   viewCount: number;
   postCount: number;
+  ratio: number;
   fanslyCreatedAt: Date;
   lastCheckedAt: Date | null;
   createdAt: Date;
@@ -48,26 +50,116 @@ interface TagStatistics {
   calculatedAt: number | null;
 }
 
-export const load: PageLoad = async ({ fetch, url }) => {
-  const page = url.searchParams.get('page') || '1';
-  const search = url.searchParams.get('search') || '';
-  const tags = url.searchParams.get('tags') || '';
-  const sortBy = 'rank';
-  const sortOrderParam = url.searchParams.get('sortOrder') || 'asc';
-  const sortOrder = sortOrderParam === 'desc' ? 'desc' : 'asc';
-  const includeHistory = url.searchParams.get('includeHistory') || 'true';
+interface TagLoadPayload {
+  tags: Tag[];
+  pagination: TagsResponse['pagination'];
+  statistics: TagStatistics;
+}
 
-  // Default to last 7 days if no dates provided
+function createDefaultTagStatistics(): TagStatistics {
+  return {
+    totalViewCount: 0,
+    totalPostCount: 0,
+    change24h: 0,
+    changePercent24h: 0,
+    postChange24h: 0,
+    postChangePercent24h: 0,
+    calculatedAt: null
+  };
+}
+
+function createEmptyPagination() {
+  return {
+    page: 1,
+    limit: 20,
+    totalCount: 0,
+    totalPages: 0
+  };
+}
+
+function getDefaultHistoryRange(url: URL) {
   const now = new Date();
   const sevenDaysAgo = new Date();
   sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
 
-  // Set end date to end of day
   const endOfDay = new Date(now);
   endOfDay.setHours(23, 59, 59, 999);
 
-  const historyStartDate = url.searchParams.get('historyStartDate') || sevenDaysAgo.toISOString();
-  const historyEndDate = url.searchParams.get('historyEndDate') || endOfDay.toISOString();
+  return {
+    historyStartDate: url.searchParams.get('historyStartDate') || sevenDaysAgo.toISOString(),
+    historyEndDate: url.searchParams.get('historyEndDate') || endOfDay.toISOString()
+  };
+}
+
+function createLoadResult(input: {
+  tags: Tag[];
+  pagination: TagsResponse['pagination'];
+  statistics: TagStatistics;
+  search: string;
+  sortBy: 'rank' | 'ratio';
+  sortOrder: 'asc' | 'desc';
+  includeHistory: string;
+  historyStartDate: string;
+  historyEndDate: string;
+}) {
+  return {
+    tags: input.tags,
+    pagination: input.pagination,
+    statistics: input.statistics,
+    search: input.search,
+    sortBy: input.sortBy,
+    sortOrder: input.sortOrder,
+    includeHistory: input.includeHistory === 'true',
+    historyStartDate: input.historyStartDate,
+    historyEndDate: input.historyEndDate
+  };
+}
+
+async function fetchTagStatistics(fetchFn: typeof fetch): Promise<TagStatistics> {
+  try {
+    const response = await fetchFn(`${PUBLIC_API_URL}/api/tags/statistics`);
+    if (!response.ok) {
+      return createDefaultTagStatistics();
+    }
+
+    return response.json();
+  } catch (statsError) {
+    console.error('Error loading tag statistics:', statsError);
+    return createDefaultTagStatistics();
+  }
+}
+
+async function fetchTagLoadPayload(
+  fetchFn: typeof fetch,
+  params: URLSearchParams
+): Promise<TagLoadPayload> {
+  const [tagsResponse, statistics] = await Promise.all([
+    fetchFn(`${PUBLIC_API_URL}/api/tags?${params}`),
+    fetchTagStatistics(fetchFn)
+  ]);
+
+  if (!tagsResponse.ok) {
+    throw new Error('Failed to fetch tags');
+  }
+
+  const data: TagsResponse = await tagsResponse.json();
+  return {
+    tags: data.tags,
+    pagination: data.pagination,
+    statistics
+  };
+}
+
+export const load: PageLoad = async ({ fetch, url }) => {
+  const page = url.searchParams.get('page') || '1';
+  const search = url.searchParams.get('search') || '';
+  const tags = url.searchParams.get('tags') || '';
+  const sortByParam = url.searchParams.get('sortBy') || 'rank';
+  const sortBy = sortByParam === 'ratio' ? 'ratio' : 'rank';
+  const sortOrderParam = url.searchParams.get('sortOrder') || 'asc';
+  const sortOrder = sortOrderParam === 'desc' ? 'desc' : 'asc';
+  const includeHistory = url.searchParams.get('includeHistory') || 'true';
+  const { historyStartDate, historyEndDate } = getDefaultHistoryRange(url);
 
   try {
     const params = new URLSearchParams({
@@ -82,72 +174,31 @@ export const load: PageLoad = async ({ fetch, url }) => {
       historyEndDate
     });
 
-    // Fetch tags data
-    const response = await fetch(`${PUBLIC_API_URL}/api/tags?${params}`);
+    const payload = await fetchTagLoadPayload(fetch, params);
 
-    if (!response.ok) {
-      throw new Error('Failed to fetch tags');
-    }
-
-    const data: TagsResponse = await response.json();
-
-    // Fetch statistics data
-    let statistics: TagStatistics = {
-      totalViewCount: 0,
-      totalPostCount: 0,
-      change24h: 0,
-      changePercent24h: 0,
-      postChange24h: 0,
-      postChangePercent24h: 0,
-      calculatedAt: null
-    };
-
-    try {
-      const statsResponse = await fetch(`${PUBLIC_API_URL}/api/tags/statistics`);
-      if (statsResponse.ok) {
-        statistics = await statsResponse.json();
-      }
-    } catch (statsError) {
-      console.error('Error loading tag statistics:', statsError);
-      // Continue with default statistics values
-    }
-
-    return {
-      tags: data.tags,
-      pagination: data.pagination,
-      statistics,
+    return createLoadResult({
+      tags: payload.tags,
+      pagination: payload.pagination,
+      statistics: payload.statistics,
       search,
       sortBy,
       sortOrder,
-      includeHistory: includeHistory === 'true',
+      includeHistory,
       historyStartDate,
       historyEndDate
-    };
+    });
   } catch (error) {
     console.error('Error loading tags:', error);
-    return {
+    return createLoadResult({
       tags: [],
-      pagination: {
-        page: 1,
-        limit: 20,
-        totalCount: 0,
-        totalPages: 0
-      },
-      statistics: {
-        totalViewCount: 0,
-        totalPostCount: 0,
-        change24h: 0,
-        changePercent24h: 0,
-        postChange24h: 0,
-        postChangePercent24h: 0,
-        calculatedAt: null
-      },
+      pagination: createEmptyPagination(),
+      statistics: createDefaultTagStatistics(),
       search,
       sortBy,
       sortOrder,
-      includeHistory: includeHistory === 'true',
+      includeHistory,
       historyStartDate,
       historyEndDate
-    };
+    });
   }
 };


### PR DESCRIPTION
Add tag ratio support to the tags table, history, and graph, and hide change series by default in the chart.

Filter '+' tags out of discovery, listing, ranking, stats, and cleanup paths, and reject manual requests for them.

Closes #109

ZerGo0 Bot