### PR TITLE
fix: optimize tag snapshots and correct ratio sorting

### DIFF
--- a/backend-go/handlers/tag_handler.go
+++ b/backend-go/handlers/tag_handler.go
@@ -82,6 +82,12 @@ type relatedTagScore struct {
 	FinalScore float64
 }
 
+type tagSortOptions struct {
+	By      string
+	Order   string
+	EndDate *time.Time
+}
+
 func extractHashtags(q string) []string {
 	if strings.TrimSpace(q) == "" {
 		return nil
@@ -140,7 +146,11 @@ func (h *TagHandler) GetTags(c *fiber.Ctx) error {
 	query.Count(&total)
 
 	needsHistory := includeHistory
-	query = h.applyTagSort(query, sortBy, sortOrder, endDate)
+	query = h.applyTagSort(query, tagSortOptions{
+		By:      sortBy,
+		Order:   sortOrder,
+		EndDate: endDate,
+	})
 
 	if len(targetTags) == 0 {
 		query = query.Limit(limit).Offset(offset)
@@ -772,21 +782,19 @@ func buildTagData(
 
 func (h *TagHandler) applyTagSort(
 	query *gorm.DB,
-	sortBy string,
-	sortOrder string,
-	endDate *time.Time,
+	sortOptions tagSortOptions,
 ) *gorm.DB {
-	if sortBy != "ratio" {
-		return query.Order("rank " + sortOrder)
+	if sortOptions.By != "ratio" {
+		return query.Order("rank " + sortOptions.Order)
 	}
 
-	orderClause := "(CASE WHEN tags.post_count > 0 THEN tags.view_count / tags.post_count ELSE 0 END) " + sortOrder
-	if endDate != nil {
-		orderClause = "(CASE WHEN COALESCE(tag_snapshots.post_count, tags.post_count) > 0 THEN COALESCE(tag_snapshots.view_count, tags.view_count) / COALESCE(tag_snapshots.post_count, tags.post_count) ELSE 0 END) " + sortOrder
-		query = query.Joins("LEFT JOIN (?) AS tag_snapshots ON tag_snapshots.tag_id = tags.id", latestTagSnapshotQuery(h.db, *endDate))
+	orderClause := currentTagRatioOrderClause()
+	if sortOptions.EndDate != nil {
+		query = query.Joins(latestTagSnapshotJoinForTagsClause(), *sortOptions.EndDate)
+		orderClause = snapshotTagRatioOrderClause()
 	}
 
-	return query.Order(orderClause).Order("rank ASC")
+	return query.Order(orderClause + " " + sortOptions.Order).Order("rank ASC")
 }
 
 func (h *TagHandler) loadTagSnapshotsForRange(
@@ -839,25 +847,20 @@ func (h *TagHandler) loadTagHistoryByTag(
 	return historyByTag, nil
 }
 
-func latestTagSnapshotQuery(db *gorm.DB, endDate time.Time) *gorm.DB {
-	latestIDs := db.Model(&models.TagHistory{}).
-		Select("tag_id, MAX(id) AS id").
-		Where("created_at <= ?", endDate).
-		Group("tag_id")
-
-	return db.Table("tag_history AS th").
-		Select("th.id, th.tag_id, th.view_count, th.change, th.post_count, th.post_count_change, th.created_at, th.updated_at").
-		Joins("JOIN (?) AS latest ON latest.id = th.id", latestIDs)
-}
-
 func loadTagSnapshots(db *gorm.DB, tagIDs []string, endDate time.Time) (map[string]models.TagHistory, error) {
 	if len(tagIDs) == 0 {
 		return map[string]models.TagHistory{}, nil
 	}
 
 	var snapshots []models.TagHistory
-	if err := db.Table("(?) AS tag_snapshots", latestTagSnapshotQuery(db, endDate)).
-		Where("tag_id IN ?", tagIDs).
+	if err := db.Table("tags AS t").
+		Select(
+			"tag_snapshots.id, tag_snapshots.tag_id, tag_snapshots.view_count, tag_snapshots.change, "+
+				"tag_snapshots.post_count, tag_snapshots.post_count_change, tag_snapshots.created_at, tag_snapshots.updated_at",
+		).
+		Joins(latestTagSnapshotJoinForSnapshotLoadClause(), endDate).
+		Where("t.id IN ?", tagIDs).
+		Where("tag_snapshots.id IS NOT NULL").
 		Scan(&snapshots).Error; err != nil {
 		return nil, err
 	}
@@ -868,6 +871,33 @@ func loadTagSnapshots(db *gorm.DB, tagIDs []string, endDate time.Time) (map[stri
 	}
 
 	return snapshotByTag, nil
+}
+
+func currentTagRatioOrderClause() string {
+	return "(CASE WHEN tags.post_count > 0 THEN " +
+		"CAST(tags.view_count AS DECIMAL(30,10)) / tags.post_count" +
+		" ELSE 0 END)"
+}
+
+func snapshotTagRatioOrderClause() string {
+	return "(CASE WHEN COALESCE(tag_snapshots.post_count, tags.post_count) > 0 THEN " +
+		"CAST(COALESCE(tag_snapshots.view_count, tags.view_count) AS DECIMAL(30,10)) / " +
+		"COALESCE(tag_snapshots.post_count, tags.post_count)" +
+		" ELSE 0 END)"
+}
+
+func latestTagSnapshotJoinForTagsClause() string {
+	return "LEFT JOIN tag_history AS tag_snapshots ON tag_snapshots.id = (" +
+		"SELECT th.id FROM tag_history AS th " +
+		"WHERE th.tag_id = tags.id AND th.created_at <= ? " +
+		"ORDER BY th.created_at DESC, th.id DESC LIMIT 1)"
+}
+
+func latestTagSnapshotJoinForSnapshotLoadClause() string {
+	return "LEFT JOIN tag_history AS tag_snapshots ON tag_snapshots.id = (" +
+		"SELECT th.id FROM tag_history AS th " +
+		"WHERE th.tag_id = t.id AND th.created_at <= ? " +
+		"ORDER BY th.created_at DESC, th.id DESC LIMIT 1)"
 }
 
 func scoreRelatedTags(rows []relatedTagAggregate, inputCount int) []relatedTagScore {

--- a/backend-go/models/tag_history.go
+++ b/backend-go/models/tag_history.go
@@ -5,13 +5,13 @@ import (
 )
 
 type TagHistory struct {
-	ID              uint      `gorm:"primaryKey;autoIncrement;column:id" json:"id"`
-	TagID           string    `gorm:"not null;index;type:varchar(255);column:tag_id;index:idx_tag_history_tag_created,priority:1" json:"tagId"`
+	ID              uint      `gorm:"primaryKey;autoIncrement;column:id;index:idx_tag_history_tag_created_id,priority:3,sort:desc" json:"id"`
+	TagID           string    `gorm:"not null;index;type:varchar(255);column:tag_id;index:idx_tag_history_tag_created,priority:1;index:idx_tag_history_tag_created_id,priority:1" json:"tagId"`
 	ViewCount       int64     `gorm:"not null;column:view_count" json:"viewCount"`
 	Change          int64     `gorm:"not null;column:change" json:"change"`
 	PostCount       int64     `gorm:"not null;default:0;column:post_count" json:"postCount"`
 	PostCountChange int64     `gorm:"not null;default:0;column:post_count_change" json:"postCountChange"`
-	CreatedAt       time.Time `gorm:"not null;column:created_at;default:CURRENT_TIMESTAMP;index;index:idx_tag_history_tag_created,priority:2,sort:desc" json:"-"`
+	CreatedAt       time.Time `gorm:"not null;column:created_at;default:CURRENT_TIMESTAMP;index;index:idx_tag_history_tag_created,priority:2,sort:desc;index:idx_tag_history_tag_created_id,priority:2,sort:desc" json:"-"`
 	UpdatedAt       time.Time `gorm:"not null;column:updated_at;default:CURRENT_TIMESTAMP" json:"-"`
 }
 

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -121,4 +121,8 @@
   body {
     @apply bg-background text-foreground h-full;
   }
+  button:not(:disabled),
+  [role='button']:not([aria-disabled='true']) {
+    @apply cursor-pointer;
+  }
 }

--- a/frontend/src/lib/components/ui/button/button.svelte
+++ b/frontend/src/lib/components/ui/button/button.svelte
@@ -4,7 +4,7 @@
   import { type VariantProps, tv } from 'tailwind-variants';
 
   export const buttonVariants = tv({
-    base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium outline-none transition-all focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+    base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium outline-none transition-all focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
     variants: {
       variant: {
         default: 'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',


### PR DESCRIPTION
Replace the tags latest-snapshot query with per-tag latest-history joins, add a composite history index, and sort ratios by the same decimal value shown in the UI.

Also add pointer cursors for enabled buttons and sortable table headers to make interactive controls behave consistently.

Closes #109

ZerGo0 Bot