### PR TITLE
ref: optimize creator and banned tag stats queries

### DIFF
--- a/backend-go/handlers/creator_handler.go
+++ b/backend-go/handlers/creator_handler.go
@@ -416,24 +416,30 @@ func (h *CreatorHandler) loadCreatorHistoryByCreator(
 		return historyByCreator, nil
 	}
 
-	histQuery := h.db.Model(&models.CreatorHistory{}).
-		Where("creator_id IN ?", creatorIDs).
-		Order("creator_id, created_at DESC")
+	const batchSize = 1000
+	for i := 0; i < len(creatorIDs); i += batchSize {
+		end := min(i+batchSize, len(creatorIDs))
+		batchIDs := creatorIDs[i:end]
 
-	if startDate != nil {
-		histQuery = histQuery.Where("created_at >= ?", *startDate)
-	}
-	if endDate != nil {
-		histQuery = histQuery.Where("created_at <= ?", *endDate)
-	}
+		histQuery := h.db.Model(&models.CreatorHistory{}).
+			Where("creator_id IN ?", batchIDs).
+			Order("creator_id, created_at DESC")
 
-	var allHistories []models.CreatorHistory
-	if err := histQuery.Find(&allHistories).Error; err != nil {
-		return nil, err
-	}
+		if startDate != nil {
+			histQuery = histQuery.Where("created_at >= ?", *startDate)
+		}
+		if endDate != nil {
+			histQuery = histQuery.Where("created_at <= ?", *endDate)
+		}
 
-	for _, history := range allHistories {
-		historyByCreator[history.CreatorID] = append(historyByCreator[history.CreatorID], history)
+		var batchHistories []models.CreatorHistory
+		if err := histQuery.Find(&batchHistories).Error; err != nil {
+			return nil, err
+		}
+
+		for _, history := range batchHistories {
+			historyByCreator[history.CreatorID] = append(historyByCreator[history.CreatorID], history)
+		}
 	}
 
 	return historyByCreator, nil
@@ -445,14 +451,11 @@ func loadCreatorSnapshots(db *gorm.DB, creatorIDs []string, endDate time.Time) (
 	}
 
 	var snapshots []models.CreatorHistory
-	if err := db.Table("creator_history AS ch").
+	if err := db.Table("creators AS c").
 		Select("ch.id, ch.creator_id, ch.media_likes, ch.post_likes, ch.followers, ch.image_count, ch.video_count, ch.created_at, ch.updated_at").
-		Joins("JOIN (?) AS latest ON latest.id = ch.id",
-			db.Model(&models.CreatorHistory{}).
-				Select("creator_id, MAX(id) AS id").
-				Where("created_at <= ? AND creator_id IN ?", endDate, creatorIDs).
-				Group("creator_id"),
-		).
+		Joins(latestCreatorSnapshotJoinClause(), endDate).
+		Where("c.id IN ?", creatorIDs).
+		Where("ch.id IS NOT NULL").
 		Scan(&snapshots).Error; err != nil {
 		return nil, err
 	}
@@ -463,4 +466,11 @@ func loadCreatorSnapshots(db *gorm.DB, creatorIDs []string, endDate time.Time) (
 	}
 
 	return snapshotByCreator, nil
+}
+
+func latestCreatorSnapshotJoinClause() string {
+	return "LEFT JOIN creator_history AS ch ON ch.id = (" +
+		"SELECT snapshot.id FROM creator_history AS snapshot FORCE INDEX (idx_creator_history_creator_created_id) " +
+		"WHERE snapshot.creator_id = c.id AND snapshot.created_at <= ? " +
+		"ORDER BY snapshot.created_at DESC, snapshot.id DESC LIMIT 1)"
 }

--- a/backend-go/handlers/tag_handler.go
+++ b/backend-go/handlers/tag_handler.go
@@ -237,39 +237,12 @@ func (h *TagHandler) GetBannedTags(c *fiber.Ctx) error {
 	offset := (page - 1) * limit
 
 	var tags []models.Tag
-	query := h.db.Model(&models.Tag{}).
-		Where("is_deleted = ?", true).
-		Where("tag NOT LIKE ?", "%+%")
-
-	if hs := extractHashtags(search); len(hs) > 0 {
-		query = query.Where("tag IN ?", hs)
-	} else if strings.HasPrefix(strings.TrimSpace(search), "#") {
-		v := strings.TrimLeft(strings.TrimSpace(search), "#")
-		if v != "" {
-			query = query.Where("tag LIKE ?", "%"+v+"%")
-		}
-	} else if search != "" {
-		query = query.Where("tag LIKE ?", "%"+search+"%")
-	}
+	query := applyBannedTagSearch(buildBannedTagBaseQuery(h.db), search)
 
 	var total int64
 	query.Count(&total)
 
-	// Map frontend sortBy values to database columns
-	columnMap := map[string]string{
-		"tag":               "tag",
-		"deletedDetectedAt": "deleted_detected_at",
-		"viewCount":         "view_count",
-		"postCount":         "post_count",
-	}
-
-	dbColumn, ok := columnMap[sortBy]
-	if !ok {
-		dbColumn = "deleted_detected_at" // default
-	}
-
-	orderClause := dbColumn + " " + sortOrder
-	query = query.Order(orderClause)
+	query = query.Order(resolveBannedTagOrderClause(sortBy, sortOrder))
 
 	query = query.Limit(limit).Offset(offset)
 
@@ -292,31 +265,10 @@ func (h *TagHandler) GetBannedTags(c *fiber.Ctx) error {
 	}
 
 	// Total banned tags
-	h.db.Model(&models.Tag{}).
-		Where("is_deleted = ?", true).
-		Where("tag NOT LIKE ?", "%+%").
-		Count(&stats.TotalBanned)
-
-	// Banned in last 24 hours
-	oneDayAgo := time.Now().Add(-24 * time.Hour)
-	h.db.Model(&models.Tag{}).
-		Where("is_deleted = ? AND deleted_detected_at >= ?", true, oneDayAgo).
-		Where("tag NOT LIKE ?", "%+%").
-		Count(&stats.BannedLast24h)
-
-	// Banned in last 7 days
-	sevenDaysAgo := time.Now().Add(-7 * 24 * time.Hour)
-	h.db.Model(&models.Tag{}).
-		Where("is_deleted = ? AND deleted_detected_at >= ?", true, sevenDaysAgo).
-		Where("tag NOT LIKE ?", "%+%").
-		Count(&stats.BannedLast7d)
-
-	// Banned in last 30 days
-	thirtyDaysAgo := time.Now().Add(-30 * 24 * time.Hour)
-	h.db.Model(&models.Tag{}).
-		Where("is_deleted = ? AND deleted_detected_at >= ?", true, thirtyDaysAgo).
-		Where("tag NOT LIKE ?", "%+%").
-		Count(&stats.BannedLast30d)
+	if err := h.loadBannedTagStatistics(&stats); err != nil {
+		zap.L().Error("Failed to fetch banned tag statistics", zap.Error(err))
+		return c.Status(500).JSON(fiber.Map{"error": "Failed to fetch banned tag statistics"})
+	}
 
 	return c.JSON(fiber.Map{
 		"tags": tags,
@@ -328,6 +280,63 @@ func (h *TagHandler) GetBannedTags(c *fiber.Ctx) error {
 		},
 		"statistics": stats,
 	})
+}
+
+func buildBannedTagBaseQuery(db *gorm.DB) *gorm.DB {
+	return db.Model(&models.Tag{}).
+		Where("is_deleted = ?", true).
+		Where("tag NOT LIKE ?", "%+%")
+}
+
+func applyBannedTagSearch(query *gorm.DB, search string) *gorm.DB {
+	if hs := extractHashtags(search); len(hs) > 0 {
+		return query.Where("tag IN ?", hs)
+	}
+
+	trimmed := strings.TrimSpace(search)
+	if strings.HasPrefix(trimmed, "#") {
+		value := strings.TrimLeft(trimmed, "#")
+		if value != "" {
+			return query.Where("tag LIKE ?", "%"+value+"%")
+		}
+		return query
+	}
+
+	if search != "" {
+		return query.Where("tag LIKE ?", "%"+search+"%")
+	}
+
+	return query
+}
+
+func resolveBannedTagOrderClause(sortBy, sortOrder string) string {
+	columnMap := map[string]string{
+		"tag":               "tag",
+		"deletedDetectedAt": "deleted_detected_at",
+		"viewCount":         "view_count",
+		"postCount":         "post_count",
+	}
+
+	if dbColumn, ok := columnMap[sortBy]; ok {
+		return dbColumn + " " + sortOrder
+	}
+
+	return "deleted_detected_at " + sortOrder
+}
+
+func (h *TagHandler) loadBannedTagStatistics(stats any) error {
+	now := time.Now()
+	return buildBannedTagBaseQuery(h.db).
+		Select(
+			"COUNT(*) AS total_banned, "+
+				"SUM(CASE WHEN deleted_detected_at >= ? THEN 1 ELSE 0 END) AS banned_last24h, "+
+				"SUM(CASE WHEN deleted_detected_at >= ? THEN 1 ELSE 0 END) AS banned_last7d, "+
+				"SUM(CASE WHEN deleted_detected_at >= ? THEN 1 ELSE 0 END) AS banned_last30d",
+			now.Add(-24*time.Hour),
+			now.Add(-7*24*time.Hour),
+			now.Add(-30*24*time.Hour),
+		).
+		Scan(stats).Error
 }
 
 func (h *TagHandler) RequestTag(c *fiber.Ctx) error {

--- a/backend-go/models/creator_history.go
+++ b/backend-go/models/creator_history.go
@@ -5,14 +5,14 @@ import (
 )
 
 type CreatorHistory struct {
-	ID         uint      `gorm:"primaryKey;autoIncrement;column:id" json:"id"`
-	CreatorID  string    `gorm:"not null;index;type:varchar(255);column:creator_id" json:"creatorId"`
+	ID         uint      `gorm:"primaryKey;autoIncrement;column:id;index:idx_creator_history_creator_created_id,priority:3,sort:desc" json:"id"`
+	CreatorID  string    `gorm:"not null;index;type:varchar(255);column:creator_id;index:idx_creator_history_creator_created,priority:1;index:idx_creator_history_creator_created_id,priority:1" json:"creatorId"`
 	MediaLikes int64     `gorm:"not null;column:media_likes" json:"mediaLikes"`
 	PostLikes  int64     `gorm:"not null;column:post_likes" json:"postLikes"`
 	Followers  int64     `gorm:"not null;column:followers" json:"followers"`
 	ImageCount int64     `gorm:"not null;column:image_count" json:"imageCount"`
 	VideoCount int64     `gorm:"not null;column:video_count" json:"videoCount"`
-	CreatedAt  time.Time `gorm:"not null;column:created_at;default:CURRENT_TIMESTAMP;index" json:"-"`
+	CreatedAt  time.Time `gorm:"not null;column:created_at;default:CURRENT_TIMESTAMP;index;index:idx_creator_history_creator_created,priority:2,sort:desc;index:idx_creator_history_creator_created_id,priority:2,sort:desc" json:"-"`
 	UpdatedAt  time.Time `gorm:"not null;column:updated_at;default:CURRENT_TIMESTAMP" json:"-"`
 }
 

--- a/frontend/src/routes/creators/+page.ts
+++ b/frontend/src/routes/creators/+page.ts
@@ -57,6 +57,44 @@ interface CreatorStatistics {
   calculatedAt: number | null;
 }
 
+function createDefaultCreatorStatistics(): CreatorStatistics {
+  return {
+    totalFollowers: 0,
+    followersChange24h: 0,
+    followersChangePercent24h: 0,
+    totalMediaLikes: 0,
+    mediaLikesChange24h: 0,
+    mediaLikesChangePercent24h: 0,
+    totalPostLikes: 0,
+    postLikesChange24h: 0,
+    postLikesChangePercent24h: 0,
+    calculatedAt: null
+  };
+}
+
+function createEmptyPagination() {
+  return {
+    page: 1,
+    limit: 20,
+    totalCount: 0,
+    totalPages: 0
+  };
+}
+
+async function fetchCreatorStatistics(fetchFn: typeof fetch): Promise<CreatorStatistics> {
+  try {
+    const response = await fetchFn(`${PUBLIC_API_URL}/api/creators/statistics`);
+    if (!response.ok) {
+      return createDefaultCreatorStatistics();
+    }
+
+    return response.json();
+  } catch (statsError) {
+    console.error('Error loading creator statistics:', statsError);
+    return createDefaultCreatorStatistics();
+  }
+}
+
 export const load: PageLoad = async ({ fetch, url }) => {
   const page = url.searchParams.get('page') || '1';
   const search = url.searchParams.get('search') || '';
@@ -89,38 +127,16 @@ export const load: PageLoad = async ({ fetch, url }) => {
       historyEndDate
     });
 
-    // Fetch creators data
-    const response = await fetch(`${PUBLIC_API_URL}/api/creators?${params}`);
+    const [response, statistics] = await Promise.all([
+      fetch(`${PUBLIC_API_URL}/api/creators?${params}`),
+      fetchCreatorStatistics(fetch)
+    ]);
 
     if (!response.ok) {
       throw new Error('Failed to fetch creators');
     }
 
     const data: CreatorsResponse = await response.json();
-
-    // Fetch statistics data
-    let statistics: CreatorStatistics = {
-      totalFollowers: 0,
-      followersChange24h: 0,
-      followersChangePercent24h: 0,
-      totalMediaLikes: 0,
-      mediaLikesChange24h: 0,
-      mediaLikesChangePercent24h: 0,
-      totalPostLikes: 0,
-      postLikesChange24h: 0,
-      postLikesChangePercent24h: 0,
-      calculatedAt: null
-    };
-
-    try {
-      const statsResponse = await fetch(`${PUBLIC_API_URL}/api/creators/statistics`);
-      if (statsResponse.ok) {
-        statistics = await statsResponse.json();
-      }
-    } catch (statsError) {
-      console.error('Error loading creator statistics:', statsError);
-      // Continue with default statistics values
-    }
 
     return {
       creators: data.creators,
@@ -137,24 +153,8 @@ export const load: PageLoad = async ({ fetch, url }) => {
     console.error('Error loading creators:', error);
     return {
       creators: [],
-      pagination: {
-        page: 1,
-        limit: 20,
-        totalCount: 0,
-        totalPages: 0
-      },
-      statistics: {
-        totalFollowers: 0,
-        followersChange24h: 0,
-        followersChangePercent24h: 0,
-        totalMediaLikes: 0,
-        mediaLikesChange24h: 0,
-        mediaLikesChangePercent24h: 0,
-        totalPostLikes: 0,
-        postLikesChange24h: 0,
-        postLikesChangePercent24h: 0,
-        calculatedAt: null
-      },
+      pagination: createEmptyPagination(),
+      statistics: createDefaultCreatorStatistics(),
       search,
       sortBy,
       sortOrder,


### PR DESCRIPTION
Speed up creators by loading end-date snapshots through the new history index and fetching stats in parallel.

Reduce banned-tag work to a single aggregate query and split handler helpers to keep complexity under control.

Closes #109

ZerGo0 Bot